### PR TITLE
Updated -- Black line-length설정 호환성 수정.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python_files = [
 
 # ==== black ====
 [tool.black]
-line-length = 100
+line-length = 88
 target-version = ["py310"]
 exclude = '''
 /(


### PR DESCRIPTION
## 작업 내용 
black의 line-length가 100으로 설정되어있고 isort, flake8은 88로 설정되어있어 호환성 문제로 충돌이 발생했습니다.
호환성을 위해 black의 line-length를 88로 수정하였습니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
