### PR TITLE
Updated -- 공용 템플릿을 관리하는 프로젝트 템플릿 설정 추가.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -10,12 +10,15 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 import environ
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+MAIN_DIR = os.path.join(BASE_DIR, "kara")
 
 env = environ.Env()
 
@@ -141,6 +144,13 @@ MIDDLEWARE = [
 # ------------------------------------------------------------------------------
 STATIC_URL = "static/"
 
+STATIC_ROOT = MAIN_DIR / "static"
+
+STATICFILES_FINDERS = [
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+]
+
 # MEDIA
 # ------------------------------------------------------------------------------
 
@@ -150,7 +160,7 @@ STATIC_URL = "static/"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(MAIN_DIR, "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
## 작업 내용
공용 템플릿을 관리하는 프로젝트 템플릿 설저을 추가했습니다.
base와 같은 공용적인 템플릿은 프로젝트 폴더인 kara/templates에서 관리하게 됩니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
