### PR TITLE
Fixed -- STATIC_ROOT설정값 수정.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -146,7 +146,7 @@ MIDDLEWARE = [
 # ------------------------------------------------------------------------------
 STATIC_URL = "static/"
 
-STATIC_ROOT = MAIN_DIR / "static"
+STATIC_ROOT = os.path.join(MAIN_DIR, "static")
 
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",


### PR DESCRIPTION
## 작업 내용 
STATIC_ROOT설정값을 수정했습니다.
기존값은 `STATIC_ROOT = MAIN_DIR / "static"`으로  문자열 간의 "/"연산을 시도하여 에러가 발생했습니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
