### PR TITLE
Updated -- 회원가입 페이지 구현.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -45,7 +45,7 @@ USE_TZ = True
 # LANGUAGE
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "ko-kr"
 USE_I18N = True
 
 # DATABASES
@@ -73,6 +73,7 @@ DJANGO_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.forms",
 ]
 
 THIRD_PARTY_APPS = [

--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -1,0 +1,86 @@
+from django import forms
+from django.contrib.auth import password_validation
+from django.contrib.auth.forms import (
+    BaseUserCreationForm,
+    SetPasswordMixin,
+    UserCreationForm,
+)
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+from .models import User
+from .widgets import FloatingLabelInput
+
+
+class CustomSetPasswordMixin(SetPasswordMixin):
+    @staticmethod
+    def create_password_fields(label1=_("Password"), label2=_("Password confirmation")):
+        password = forms.CharField(
+            required=True,
+            strip=False,
+            widget=FloatingLabelInput(
+                attrs={
+                    "label": label1,
+                    "type": "password",
+                    "autocomplete": "new-password",
+                }
+            ),
+            help_text=password_validation.password_validators_help_text_html(),
+        )
+        password_confirmation = forms.CharField(
+            label=label2,
+            required=True,
+            widget=FloatingLabelInput(
+                attrs={
+                    "label": label2,
+                    "type": "password",
+                    "autocomplete": "new-password",
+                }
+            ),
+            strip=False,
+            help_text=_("Enter the same password as before, for verification."),
+        )
+        return password, password_confirmation
+
+
+class CustomUserCreationForm(UserCreationForm, forms.ModelForm):
+    username = forms.CharField(
+        min_length=4,
+        widget=FloatingLabelInput(
+            attrs={"label": _("Username"), "type": "text", "autocomplete": "username"}
+        ),
+    )
+    email = forms.EmailField(
+        widget=FloatingLabelInput(
+            attrs={
+                "label": _("Email"),
+                "type": "email",
+                "autocomplete": "email",
+            }
+        )
+    )
+    password1, password2 = CustomSetPasswordMixin.create_password_fields()
+
+    class Meta:
+        model = User
+        fields = (
+            "username",
+            "email",
+            "password1",
+            "password2",
+        )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+    def _post_clean(self):
+        super(BaseUserCreationForm, self)._post_clean()
+        # Validate the password after self.instance is updated with form data
+        # by super().
+        password = self.cleaned_data.get("password2")
+        if password:
+            try:
+                password_validation.validate_password(password, self.instance)
+            except ValidationError as error:
+                self.add_error("password1", error)

--- a/kara/accounts/tests/test_views.py
+++ b/kara/accounts/tests/test_views.py
@@ -1,0 +1,29 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from kara.accounts.models import User
+
+
+class SignupViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("signup")
+
+    def test_signup_template_render(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Registration")
+
+    def test_signup_success(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "username": "strawberry",
+                "email": "strawberry@farm.com",
+                "password1": "*password*",
+                "password2": "*password*",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(User.objects.filter(username="strawberry").exists())

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -1,7 +1,7 @@
-from allauth.account import views
 from django.urls import path
 
+from . import views
+
 urlpatterns = [
-    path("login/", views.login, name="account_login"),
-    path("signup/", views.signup, name="account_signup"),
+    path("signup/", views.SignupView.as_view(), name="signup"),
 ]

--- a/kara/accounts/views.py
+++ b/kara/accounts/views.py
@@ -1,0 +1,28 @@
+from django.contrib import messages
+from django.urls import reverse
+from django.views.generic import FormView
+
+from .forms import CustomUserCreationForm
+
+
+def send_user_confirmation_email():
+    pass
+
+
+class SignupView(FormView):
+    form_class = CustomUserCreationForm
+    template_name = "registration/signup.html"
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            "Your registration was successful. Please check "
+            "your email provided for a confirmation link.",
+        )
+        return reverse("signup")
+
+    def form_valid(self, form):
+        form.save()
+        send_user_confirmation_email()
+        return super().form_valid(form)

--- a/kara/accounts/widgets.py
+++ b/kara/accounts/widgets.py
@@ -1,0 +1,5 @@
+from django.forms.widgets import Input
+
+
+class FloatingLabelInput(Input):
+    template_name = "accounts/widgets/floating_label_input.html"

--- a/kara/templates/registration/signup.html
+++ b/kara/templates/registration/signup.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% load allauth i18n static %}
+
+{% block title %}{% translate "Registration | Kara" %}{% endblock %}
+
+{% block meta_title %}{% translate "Registration | Kara" %}{% endblock %}
+
+{% block content %}
+<main class="my-5 mx-8 flex">
+    <div class="flex-1 px-20">
+        <h1 class="text-5xl">{% translate "Registration" %}</h1>
+        {% setvar link %}
+            <a class="text-kara-strong hover:text-kara-deep transition-colors duration-300" href="{{ login_url }}">
+            {% endsetvar %}
+            {% setvar end_link %}
+            </a>
+        {% endsetvar %}
+        <p class="pt-4">
+            {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
+        </p>
+        <div class="row">
+            <div class="col">
+                <form class="space-y-8" method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="field-container">
+                            {{ field.as_field_group }}
+                        </div>
+                    {% endfor %}
+                    <button
+                    type="submit"
+                    class="
+                    text-lg w-full bg-kara-shallow py-3 rounded-lg text-white transition-colors duration-500
+                    hover:bg-kara-very-shallow hover:text-kara-deep
+                    "
+                    >
+                    {% translate "Signup" %}
+                    </button>
+                </form>
+            </div>
+            <div class="col"></div>
+        </div>
+    </div>
+    <div class="flex-1">
+    </div>    
+</main>
+{% endblock content %}

--- a/kara/theme/static/css/dist/styles.css
+++ b/kara/theme/static/css/dist/styles.css
@@ -807,9 +807,19 @@ select {
   z-index: 10;
 }
 
+.mx-8 {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
+}
+
+.my-5 {
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
 }
 
 .mb-auto {
@@ -842,6 +852,10 @@ select {
 
 .max-w-screen-xl {
   max-width: 1280px;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
 }
 
 .origin-\[0\] {
@@ -881,6 +895,12 @@ select {
   justify-content: center;
 }
 
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
 .rounded-lg {
   border-radius: 0.5rem;
 }
@@ -889,9 +909,19 @@ select {
   border-width: 2px;
 }
 
+.border-kara-shallow {
+  --tw-border-opacity: 1;
+  border-color: rgb(245 200 200 / var(--tw-border-opacity, 1));
+}
+
 .bg-gray-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+
+.bg-kara-shallow {
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 200 200 / var(--tw-bg-opacity, 1));
 }
 
 .bg-transparent {
@@ -913,12 +943,22 @@ select {
   padding-right: 0.625rem;
 }
 
-.pl-1 {
-  padding-left: 0.25rem;
+.px-20 {
+  padding-left: 5rem;
+  padding-right: 5rem;
+}
+
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
 }
 
 .pb-2\.5 {
   padding-bottom: 0.625rem;
+}
+
+.pl-1 {
+  padding-left: 0.25rem;
 }
 
 .pt-4 {
@@ -952,8 +992,53 @@ select {
   color: rgb(17 24 39 / var(--tw-text-opacity, 1));
 }
 
+.text-kara-shallow {
+  --tw-text-opacity: 1;
+  color: rgb(245 200 200 / var(--tw-text-opacity, 1));
+}
+
+.text-kara-strong {
+  --tw-text-opacity: 1;
+  color: rgb(243 176 176 / var(--tw-text-opacity, 1));
+}
+
+.text-state-fail {
+  --tw-text-opacity: 1;
+  color: rgb(227 55 47 / var(--tw-text-opacity, 1));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .duration-300 {
   transition-duration: 300ms;
+}
+
+.duration-500 {
+  transition-duration: 500ms;
+}
+
+.hover\:bg-kara-very-shallow:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 238 238 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:text-kara-deep:hover {
+  --tw-text-opacity: 1;
+  color: rgb(227 130 130 / var(--tw-text-opacity, 1));
+}
+
+.focus\:border-kara-strong:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 176 176 / var(--tw-border-opacity, 1));
 }
 
 .focus\:outline-none:focus {
@@ -1017,6 +1102,11 @@ select {
   padding-right: 0.5rem;
 }
 
+.peer:focus ~ .peer-focus\:text-kara-strong {
+  --tw-text-opacity: 1;
+  color: rgb(243 176 176 / var(--tw-text-opacity, 1));
+}
+
 .peer:not(:-moz-placeholder-shown) ~ .peer-\[\&\:not\(\:-moz-placeholder-shown\)\]\:-translate-y-6 {
   --tw-translate-y: -1.5rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -1025,6 +1115,16 @@ select {
 .peer:not(:placeholder-shown) ~ .peer-\[\&\:not\(\:placeholder-shown\)\]\:-translate-y-6 {
   --tw-translate-y: -1.5rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.peer:not(:-moz-placeholder-shown) ~ .peer-\[\&\:not\(\:-moz-placeholder-shown\)\]\:text-kara-strong {
+  --tw-text-opacity: 1;
+  color: rgb(243 176 176 / var(--tw-text-opacity, 1));
+}
+
+.peer:not(:placeholder-shown) ~ .peer-\[\&\:not\(\:placeholder-shown\)\]\:text-kara-strong {
+  --tw-text-opacity: 1;
+  color: rgb(243 176 176 / var(--tw-text-opacity, 1));
 }
 
 .peer:focus ~ .rtl\:peer-focus\:left-auto:where([dir="rtl"], [dir="rtl"] *) {

--- a/kara/theme/static_src/tailwind.config.js
+++ b/kara/theme/static_src/tailwind.config.js
@@ -42,7 +42,22 @@ module.exports = {
         // '../../**/*.py'
     ],
     theme: {
-        extend: {},
+        extend: {
+            colors: {
+                kara: {
+                    "very-shallow": "#FFEEEE",
+                    shallow: "#F5C8C8",
+                    strong: "#F3B0B0",
+                    deep: "#E38282",
+                    base: "#f3AEAE",
+                },
+                state: {
+                    "success": "#4BA324",
+                    "warning": "#DF9F2F",
+                    "fail": "#E3372F",
+                }
+            }
+        },
     },
     plugins: [
         /**


### PR DESCRIPTION
## 작업 내용 
회원가입 페이지를 구현했습니다.
대부분의 Input의 widget을 floating_label을 사용하도록 했습니다.
```
    def get_success_url(self):
        messages.add_message(
            self.request,
            messages.INFO,
            "Your registration was successful. Please check "
            "your email provided for a confirmation link.",
        )
        return reverse("signup")
```
`SignupView`에서 회원가입 성공시 리디렉션은 이메일 인증 페이지지만 아직 페이지가 제작중에 있기때문에 `"signup"`을 임시로 사용했습니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/1

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
