### PR TITLE
Updated -- 이메일 인증코드 재발급 로직 구현.

### DIFF
--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -17,6 +17,7 @@ class EmailVerificationCodeForm(forms.Form):
         widget=FloatingLabelInput(attrs={"label": _("Confirmation Code")}),
         max_length=6,
         help_text=_("Enter the 6-digit verification code sent to your email."),
+        required=False,
     )
 
     def __init__(self, *args, **kwargs):

--- a/kara/accounts/tests/test_views.py
+++ b/kara/accounts/tests/test_views.py
@@ -2,6 +2,7 @@ from django.core import mail
 from django.test import Client, TestCase
 from django.urls import reverse
 
+from kara.accounts.factories import UserFactory
 from kara.accounts.models import User
 
 
@@ -82,10 +83,53 @@ class ConfirmEmailVerificationCodeViewTests(TestCase):
     def test_email_verification_success(self):
         response = self.client.post(
             self.url,
-            data={"code": self.verification_code},
+            data={"code": self.verification_code, "action_confirm": "1"},
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
         user = User.objects.get(username="watermelon")
         self.assertTrue(user.profile.email_confirmed)
         self.assertNotIn("pending_email_confirmation", self.client.session)
+
+    def test_resend_email_confirmation_code(self):
+        mail_cnt = len(mail.outbox)
+        response = self.client.post(
+            self.url,
+            data={"action_resend": "1"},
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), mail_cnt + 1)
+        self.assertEqual(mail.outbox[-1].subject, "Kara Email Confirmation")
+        self.assertIn(
+            "Please enter the 6-digit email verification code on the "
+            "email verification page.",
+            mail.outbox[-1].body,
+        )
+
+
+class ResendEmailConfirmationViewTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(username="mango", email="mango@farm.com")
+        cls.url = reverse("email_confirmation_resend")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+
+    def test_redirect_template_render(self):
+        response = self.client.post(self.url, {}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Please check your inbox!")
+        self.assertContains(response, "mango@farm.com")
+
+    def test_resend_email(self):
+        self.client.post(self.url, {}, follow=True)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "Kara Email Confirmation")
+        self.assertIn(
+            "Please enter the 6-digit email verification code on the "
+            "email verification page.",
+            mail.outbox[0].body,
+        )

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -10,4 +10,9 @@ urlpatterns = [
         views.EmailConfirmationView.as_view(),
         name="email_confirmation",
     ),
+    path(
+        "email/confirmation/resend/",
+        views.ResendEmailConfirmationView.as_view(),
+        name="email_confirmation_resend",
+    ),
 ]

--- a/kara/templates/registration/email_confirmation.html
+++ b/kara/templates/registration/email_confirmation.html
@@ -19,17 +19,31 @@
                             {{ field.as_field_group }}
                         </div>
                     {% endfor %}
+                    <div class="pl-1 flex mt-4 mb-2">
+                        <button 
+                        type="submit"
+                        name="action_resend"
+                        class="
+                        resend-code text-kara-strong hover:text-kara-deep transition-colors duration-500 mr-4
+                        disabled:text-kara-shallow disabled:cursor-default disabled:opacity-80
+                        "
+                        >
+                        {% translate "Resend Code" %}
+                        </button>
+                        <div class="timer"></div>
+                    </div>
                     <button
                     type="submit"
+                    name="action_confirm"
                     class="
-                    w-full text-lg my-6 bg-kara-shallow py-3 rounded-lg text-white transition-colors duration-500
+                    w-full text-lg bg-kara-shallow py-3 rounded-lg text-white transition-colors duration-500
                     hover:bg-kara-very-shallow hover:text-kara-strong
                     "
                     >
                     {% translate "Verify Code" %}
                     </button>
                 </form>
-                <div class="flex items-center justify-center">
+                <div class="flex items-center justify-center mt-4">
                     <a href="{{ later_confirm_link }}" class="text-kara-strong hover:text-kara-deep transition-colors duration-500">{% translate "I'll confirm later!"%}</a>
                 </div>
             </div>

--- a/kara/theme/static/css/dist/styles.css
+++ b/kara/theme/static/css/dist/styles.css
@@ -827,6 +827,16 @@ select {
   margin-bottom: 1.5rem;
 }
 
+.my-4 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .mb-auto {
   margin-bottom: auto;
 }
@@ -837,6 +847,38 @@ select {
 
 .mt-1 {
   margin-top: 0.25rem;
+}
+
+.mt-0 {
+  margin-top: 0px;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
+.mr-4 {
+  margin-right: 1rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mb-0\.5 {
+  margin-bottom: 0.125rem;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
 }
 
 .block {
@@ -920,6 +962,10 @@ select {
   justify-content: center;
 }
 
+.justify-between {
+  justify-content: space-between;
+}
+
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
@@ -980,6 +1026,11 @@ select {
 .py-3 {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
+}
+
+.px-1 {
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 .pb-2\.5 {
@@ -1107,6 +1158,27 @@ select {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.disabled\:cursor-default:disabled {
+  cursor: default;
+}
+
+.disabled\:text-kara-shallow:disabled {
+  --tw-text-opacity: 1;
+  color: rgb(245 200 200 / var(--tw-text-opacity, 1));
+}
+
+.disabled\:opacity-50:disabled {
+  opacity: 0.5;
+}
+
+.disabled\:opacity-30:disabled {
+  opacity: 0.3;
+}
+
+.disabled\:opacity-80:disabled {
+  opacity: 0.8;
 }
 
 .peer:-moz-placeholder-shown ~ .peer-placeholder-shown\:top-1\/2 {


### PR DESCRIPTION
## 작업 내용
이메일 인증코드 재발급 로직을 구현했습니다.
이메일 인증코드 재발급은 프로필(예정), 이메일 인증 페이지에 추가됩니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/31

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
