### PR TITLE
Updated -- 인증코드 인증 실패시 에러메시지 추가.

### DIFF
--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -32,7 +32,7 @@ class EmailVerificationCodeForm(forms.Form):
     def clean_code(self):
         code = self.cleaned_data.get("code")
         if not self.compare_code(server=self.code, client=code):
-            raise ValueError()
+            self.add_error("code", _("The verification code does not match."))
         return code
 
 

--- a/kara/accounts/tests/test_views.py
+++ b/kara/accounts/tests/test_views.py
@@ -91,6 +91,16 @@ class ConfirmEmailVerificationCodeViewTests(TestCase):
         self.assertTrue(user.profile.email_confirmed)
         self.assertNotIn("pending_email_confirmation", self.client.session)
 
+    def test_email_verification_fail(self):
+        response = self.client.post(
+            self.url,
+            data={"code": 123456, "action_confirm": "1"},
+            follow=True,
+        )
+        self.assertContains(
+            response, "<li>The verification code does not match.</li>", html=True
+        )
+
     def test_resend_email_confirmation_code(self):
         mail_cnt = len(mail.outbox)
         response = self.client.post(

--- a/kara/templates/forms/field.html
+++ b/kara/templates/forms/field.html
@@ -1,6 +1,6 @@
 {{ field }}
 {% if field.errors %}
-    <ul class="mt-2 pl-1 text-state-fail w-inherit">{% for error in field.errors %}<li>{{ error }}</li>{% endfor %}</ul>
+    <ul class="text-sm mt-2 pl-1 text-state-fail w-inherit">{% for error in field.errors %}<li>{{ error }}</li>{% endfor %}</ul>
 {% elif field.help_text%}
-    <div class="helptext mt-2 pl-1 w-inherit"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</div>
+    <div class="text-sm helptext mt-2 pl-1 w-inherit"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</div>
 {% endif %}

--- a/kara/templates/registration/email_confirmation.html
+++ b/kara/templates/registration/email_confirmation.html
@@ -10,7 +10,7 @@
     <div class="h-full flex flex-1 flex-col items-center justify-center">
         <h1 class="text-4xl">{% translate "Please check your inbox!" %}</h1>
         <p class="my-6 text-center">{% blocktranslate %}To complete your registration, please enter the 6-digit code sent to <span class="text-kara-deep">{{ email }}</span>{% endblocktranslate %}</p>
-        <div class="row">
+        <div class="row w-4/5">
             <div class="col">
                 <form method="post">
                     {% csrf_token %}

--- a/kara/theme/static/css/dist/styles.css
+++ b/kara/theme/static/css/dist/styles.css
@@ -1068,6 +1068,11 @@ select {
   line-height: 2.5rem;
 }
 
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
 .leading-normal {
   line-height: 1.5;
 }


### PR DESCRIPTION
## 작업 내용 
인증코드 인증 실패시(일치하지 않는 인증코드) 에러메시지를 추가했습니다.
<img width="429" alt="Screenshot 2025-04-04 at 4 23 28 PM" src="https://github.com/user-attachments/assets/e4ce58e4-4b84-415d-ab8c-c9f1202f32b3" />

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
