### PR TITLE
Updated -- title과 같은 메인 텍스트에 폰트와 색상, 마진을 추가.

### DIFF
--- a/kara/templates/base.html
+++ b/kara/templates/base.html
@@ -7,9 +7,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
         <meta name="title" content="{% block meta_title %}{% endblock meta_title %}"/>
+        <link rel="stylesheet" href="{% static "css/dist/fonts.css" %}">
         {% tailwind_css %}
 	</head>
-    <body class="flex flex-col h-screen {% block body_class %}{% endblock %}">
+    <body class="flex flex-col h-screen font-common {% block body_class %}{% endblock %}">
         <div class="container flex justify-center mb-auto mx-auto max-w-screen-xl">
             <div class="w-4/5">
                 {% block content %}

--- a/kara/templates/registration/email_confirmation.html
+++ b/kara/templates/registration/email_confirmation.html
@@ -8,7 +8,7 @@
 {% block content %}
 <main class="h-screen my-5 mx-8 flex">
     <div class="h-full flex flex-1 flex-col items-center justify-center">
-        <h1 class="text-4xl">{% translate "Please check your inbox!" %}</h1>
+        <h1 class="text-5xl font-title tracking-[.07em] text-kara-light-deep mb-2">{% translate "Please check your inbox!" %}</h1>
         <p class="my-6 text-center">{% blocktranslate %}To complete your registration, please enter the 6-digit code sent to <span class="text-kara-deep">{{ email }}</span>{% endblocktranslate %}</p>
         <div class="row w-4/5">
             <div class="col">

--- a/kara/templates/registration/signup.html
+++ b/kara/templates/registration/signup.html
@@ -8,7 +8,7 @@
 {% block content %}
 <main class="my-5 mx-8 flex">
     <div class="flex-1 px-20">
-        <h1 class="text-5xl">{% translate "Registration" %}</h1>
+        <h1 class="text-6xl font-title mb-4 tracking-[.2em] text-kara-light-deep">{% translate "Registration" %}</h1>
         {% setvar link %}
             <a class="text-kara-strong hover:text-kara-deep transition-colors duration-300" href="{{ login_url }}">
             {% endsetvar %}

--- a/kara/theme/static/css/dist/fonts.css
+++ b/kara/theme/static/css/dist/fonts.css
@@ -1,0 +1,13 @@
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'LeeSeoyun';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2202-2@1.0/LeeSeoyun.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}

--- a/kara/theme/static/css/dist/styles.css
+++ b/kara/theme/static/css/dist/styles.css
@@ -154,7 +154,7 @@ html,
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: "Pretendard-Regular", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -827,13 +827,12 @@ select {
   margin-bottom: 1.5rem;
 }
 
-.my-8 {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
-}
-
 .mb-2 {
   margin-bottom: 0.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
 }
 
 .mb-auto {
@@ -850,14 +849,6 @@ select {
 
 .mt-4 {
   margin-top: 1rem;
-}
-
-.mb-6 {
-  margin-bottom: 1.5rem;
-}
-
-.mt-8 {
-  margin-top: 2rem;
 }
 
 .block {
@@ -1019,17 +1010,25 @@ select {
   text-align: center;
 }
 
+.font-common {
+  font-family: Pretendard-Regular;
+}
+
 .font-serif {
   font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 }
 
-.text-4xl {
-  font-size: 2.25rem;
-  line-height: 2.5rem;
+.font-title {
+  font-family: LeeSeoyun;
 }
 
 .text-5xl {
   font-size: 3rem;
+  line-height: 1;
+}
+
+.text-6xl {
+  font-size: 3.75rem;
   line-height: 1;
 }
 
@@ -1047,6 +1046,14 @@ select {
   line-height: 1.5;
 }
 
+.tracking-\[\.07em\] {
+  letter-spacing: .07em;
+}
+
+.tracking-\[\.2em\] {
+  letter-spacing: .2em;
+}
+
 .tracking-normal {
   letter-spacing: 0em;
 }
@@ -1059,6 +1066,11 @@ select {
 .text-kara-deep {
   --tw-text-opacity: 1;
   color: rgb(227 130 130 / var(--tw-text-opacity, 1));
+}
+
+.text-kara-light-deep {
+  --tw-text-opacity: 1;
+  color: rgb(244 132 132 / var(--tw-text-opacity, 1));
 }
 
 .text-kara-shallow {
@@ -1262,11 +1274,4 @@ select {
     --tw-text-opacity: 1;
     color: rgb(59 130 246 / var(--tw-text-opacity, 1));
   }
-}
-
-@font-face {
-  font-family: 'Pretendard-Regular';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
 }

--- a/kara/theme/static_src/tailwind.config.js
+++ b/kara/theme/static_src/tailwind.config.js
@@ -46,16 +46,21 @@ module.exports = {
             colors: {
                 kara: {
                     "very-shallow": "#FFEEEE",
-                    shallow: "#F5C8C8",
-                    strong: "#F3B0B0",
-                    deep: "#E38282",
-                    base: "#f3AEAE",
+                    "shallow": "#F5C8C8",
+                    "strong": "#F3B0B0",
+                    "deep": "#E38282",
+                    "light-deep": "#f48484",
+                    "base": "#f3AEAE",
                 },
                 state: {
                     "success": "#4BA324",
                     "warning": "#DF9F2F",
                     "fail": "#E3372F",
-                }
+                },
+            },
+            fontFamily: {
+                title: ["LeeSeoyun"],
+                common: ["Pretendard-Regular"],
             }
         },
     },


### PR DESCRIPTION
## 작업 내용
title과 같은 메인 텍스트에 폰트와 색상, 마진을 추가했습니다.
<img width="260" alt="Screenshot 2025-04-04 at 6 10 52 PM" src="https://github.com/user-attachments/assets/ab035cf1-a22c-4039-a7c5-73a0ebbdeec4" />
조금 어색할경우에 주변에 이모지같은 부분을 추가하면 더 좋을거같습니다.
추가로 fonts를 css에서 따로 분리해서 적용했습니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
