### PR TITLE
Updated -- 로그인 아이디입력시 이메일 입력 허용.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -100,9 +100,8 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 # AUTHENTICATION
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#authentication-backends
-AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",
-]
+AUTHENTICATION_BACKENDS = ["kara.accounts.backends.AuthenticationBackend"]
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#auth-user-model
 AUTH_USER_MODEL = "accounts.User"
 

--- a/kara/accounts/backends.py
+++ b/kara/accounts/backends.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.backends import ModelBackend
+from django.db.models import Q
+
+from .models import User
+
+
+class AuthenticationBackend(ModelBackend):
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        if username is None or password is None:
+            return
+        try:
+            user = User._default_manager.get(Q(username=username) | Q(email=username))
+        except User.DoesNotExist:
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a nonexistent user (#20760).
+            User().set_password(password)
+        else:
+            if user.check_password(password) and self.user_can_authenticate(user):
+                return user

--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -72,7 +72,7 @@ class CustomSetPasswordMixin(SetPasswordMixin):
 class CustomAuthenticationForm(AuthenticationForm):
     username = UsernameField(
         widget=FloatingLabelInput(
-            attrs={"label": _("Username"), "type": "text", "autofocus": True}
+            attrs={"label": _("Username or Email"), "type": "text", "autofocus": True}
         )
     )
     password = forms.CharField(

--- a/kara/accounts/locale/ko/LC_MESSAGES/django.po
+++ b/kara/accounts/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-07 13:56+0900\n"
+"POT-Creation-Date: 2025-04-07 16:35+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgstr "이메일로 전송된 6자리 인증 코드를 입력하세요."
 msgid "The verification code does not match."
 msgstr "인증 코드가 일치하지 않습니다."
 
-#: kara/accounts/forms.py:43 kara/accounts/forms.py:80
+#: kara/accounts/forms.py:43 kara/accounts/forms.py:82
 msgid "Password"
 msgstr "비밀번호"
 
@@ -42,23 +42,27 @@ msgstr "비밀번호 확인"
 msgid "Enter the same password as before, for verification."
 msgstr "확인을 위해 앞에서 입력한 비밀번호와 동일한 값을 입력하세요."
 
-#: kara/accounts/forms.py:74 kara/accounts/forms.py:92
+#: kara/accounts/forms.py:75
+msgid "Username or Email"
+msgstr "아이디 또는 이메일"
+
+#: kara/accounts/forms.py:94
 msgid "Username"
 msgstr "사용자 이름"
 
-#: kara/accounts/forms.py:98
+#: kara/accounts/forms.py:100
 msgid "Email"
 msgstr "이메일"
 
-#: kara/accounts/views.py:86
+#: kara/accounts/views.py:89
 msgid "Email verification is complete!"
 msgstr "이메일 인증이 완료되었습니다!"
 
-#: kara/accounts/views.py:118
+#: kara/accounts/views.py:121
 msgid "The email verification code has been resent."
 msgstr "이메일 인증 코드가 다시 전송되었습니다."
 
-#: kara/accounts/views.py:137
+#: kara/accounts/views.py:140
 msgid ""
 "Your registration was successful. Please check your email provided for a "
 "verification code."

--- a/kara/accounts/tests/test_login_view.py
+++ b/kara/accounts/tests/test_login_view.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from kara.accounts.factories import UserFactory
+
+
+class LoginViewTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            username="egg123", email="egg123@cookie.com", password="password"
+        )
+        cls.user.set_password(cls.user.password)
+        cls.user.save()
+        cls.url = reverse("login")
+
+    def test_login(self):
+        response = self.client.post(
+            self.url,
+            {
+                "username": "egg123",
+                "password": "password",
+            },
+        )
+        self.assertEqual(response.url, "/")
+        self.assertEqual(response.status_code, 302)
+        response = self.client.post(
+            self.url,
+            {
+                "username": "egg123@cookie.com",
+                "password": "password",
+            },
+        )
+        self.assertEqual(response.url, "/")
+        self.assertEqual(response.status_code, 302)

--- a/kara/locale/ko/LC_MESSAGES/django.po
+++ b/kara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-07 14:05+0900\n"
+"POT-Creation-Date: 2025-04-07 16:35+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,15 +49,16 @@ msgid "I'll confirm later!"
 msgstr "나중에 인증할게요!"
 
 #: kara/templates/registration/login.html:4
+#: kara/templates/registration/login.html:6
 msgid "Login | kara"
 msgstr "로그인 | Kara"
 
-#: kara/templates/registration/login.html:21
+#: kara/templates/registration/login.html:20
 #, python-format
 msgid "Don't have an account you? %(link)ssignup%(end_link)s"
 msgstr "아직 계정이 없나요? %(link)s회원가입%(end_link)s"
 
-#: kara/templates/registration/login.html:33
+#: kara/templates/registration/login.html:32
 msgid "Login"
 msgstr "로그인"
 


### PR DESCRIPTION
## 작업 내용
로그인할때 이메일 입력을 허용했습니다.
기존에는 아이디, 비밀번호만 허용했지만 이메일, 비밀번호도 허용되도록 변경했습니다.
<img width="474" alt="Screenshot 2025-04-07 at 4 43 42 PM" src="https://github.com/user-attachments/assets/e5ae9e86-2f0a-4722-8a58-38d025c0f83a" />

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/52

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
