### PR TITLE
Fixed -- 가입하기 버튼이 화면 넓이가 sm이하일때 사라지는 현상 수정.

### DIFF
--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -26,11 +26,11 @@
         </nav>
         {% if not user.is_authenticated %}
         <div class="flex items-center gap-4">
-            <div class="sm:flex sm:gap-4">
+            <div class="hidden flex-row sm:flex gap-4">
                 <a class="block rounded-md bg-kara-very-shallow px-4 py-2.5 text-sm font-medium duration-500 text-kara-deep transition hover:bg-kara-strong hover:text-white cursor-pointer" href="{% url 'login' %}">
                   {% trans 'Login' %}
                 </a>
-                <a class="hidden rounded-md bg-kara-strong px-5 py-2.5 text-sm font-medium text-white duration-500 transition hover:bg-kara-deep sm:block cursor-pointer" href="{% url 'signup' %}">
+                <a class="block rounded-md bg-kara-strong px-5 py-2.5 text-sm font-medium text-white duration-500 transition hover:bg-kara-deep cursor-pointer" href="{% url 'signup' %}">
                   {% trans 'Sign Up' %}
                 </a>
             </div>


### PR DESCRIPTION
## 작업 내용
가입하기 버튼 클래스에 `hidden sm:block`이 존재했기 때문에 뷰포트가 sm이하일때 가입하기 버튼이 hidden처리 되었습니다.
이 부분을 제거하고 뷰포트가 sm이하일때 로그인 버튼또한 hidden처리 되도록 수정했습니다.
sm이하일때 사이바 패널에 시작하기! 버튼을 통해 로그인, 회원가입 페이지로 이동할 수 있기 때문에 뷰포트가 sm이하일때 로그인, 회원가입 버튼을 제거해도 문제없다고 판단했습니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
