### PR TITLE
Updated -- 네비게이션바 인증된 유저 미니 프로필 버튼 추가.

### DIFF
--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -1,6 +1,6 @@
 {% load i18n static %}
 <nav class="bg-white">
-    <div class="mx-4 flex h-18 items-center gap-12 px-1 sm:px-4 lg:px-2">
+    <div class="mx-4 flex h-18 items-center gap-12 px-1 py-2 sm:px-4 lg:px-2">
         <a class="block text-teal-600" href={% url 'home' %}>
             <img alt="KARA" class="brand-icon" src="{% static 'img/kara_logo.png' %}"/>
         </a>
@@ -24,8 +24,8 @@
                 </li>
             </ul>
         </nav>
-        {% if not user.is_authenticated %}
         <div class="flex items-center gap-4">
+            {% if not user.is_authenticated %}
             <div class="hidden flex-row sm:flex gap-4">
                 <a class="block rounded-md bg-kara-very-shallow px-4 py-2.5 text-sm font-medium duration-500 text-kara-deep transition hover:bg-kara-strong hover:text-white cursor-pointer" href="{% url 'login' %}">
                   {% trans 'Login' %}
@@ -77,10 +77,18 @@
                         <a class="block w-full py-3 mt-10 bg-kara-strong text-white text-center transition-color duration-500 border rounded-lg border-kara-strong hover:bg-white hover:text-kara-strong" role="button" href="{% url 'login' %}">{% trans 'Get started!' %}</a>
                     </div>
                 </div>
+                {% else %}
+                <button
+                class="
+                w-[50px] h-[50px] rounded-full p-1 bg-transparent cursor-pointer 
+                overflow-hidden transition-all duration-500 ease-in-out
+                hover:ring-2 hover:ring-kara-deep
+                "
+                >
+                    <img alt="profile" src="{{ user.profile.bio_image.url }}"/>
+                </button>
+                {% endif %}
             </div>
-        {% else %}
-            <div class="profile"></div>
-        {% endif %}
         </div>
     </div>
 </nav>


### PR DESCRIPTION
## 작업 내용 
인증된 유저에게 렌더링되는 네비게이션바에 미니 프로필 버튼을 추가했습니다.
<img width="871" alt="Screenshot 2025-04-11 at 11 35 26 AM" src="https://github.com/user-attachments/assets/9521f7d9-62b2-454c-8937-931ee834a8f8" />

위 이미지에서는 기본 이미지가 사용되었으며 클라이언트의 프로필이미지에 따라 변화됩니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
