### PR TITLE
Updated -- 네비게이션바 인증된 유저에게 렌더링되는 사이드바 추가.

### DIFF
--- a/kara/locale/ko/LC_MESSAGES/django.po
+++ b/kara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-10 17:48+0900\n"
+"POT-Creation-Date: 2025-04-11 16:38+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,15 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: kara/templates/includes/nav.html:12 kara/templates/includes/nav.html:61
+#: kara/templates/includes/nav.html:12 kara/templates/includes/nav.html:60
 msgid "Program Information"
 msgstr "프로그램 정보"
 
-#: kara/templates/includes/nav.html:17 kara/templates/includes/nav.html:66
+#: kara/templates/includes/nav.html:17 kara/templates/includes/nav.html:65
+#: kara/templates/includes/nav.html:120
 msgid "Gift Tracker"
 msgstr "축의금 기록하기"
 
-#: kara/templates/includes/nav.html:22 kara/templates/includes/nav.html:71
+#: kara/templates/includes/nav.html:22 kara/templates/includes/nav.html:70
+#: kara/templates/includes/nav.html:123
 msgid "My Wedding Expenses"
 msgstr "나의 결혼 비용"
 
@@ -39,9 +41,26 @@ msgstr "로그인"
 msgid "Sign Up"
 msgstr "가입하기"
 
-#: kara/templates/includes/nav.html:77
+#: kara/templates/includes/nav.html:74
 msgid "Get started!"
 msgstr "시작하기!"
+
+#: kara/templates/includes/nav.html:107
+msgid "Back"
+msgstr "닫기"
+
+#: kara/templates/includes/nav.html:115
+#, python-format
+msgid "Welcome, %(username)s! How's your day going today 🙌"
+msgstr "환영합니다, %(username)s!님 오늘 하루는 어떤가요 🙌"
+
+#: kara/templates/includes/nav.html:126
+msgid "Profile"
+msgstr "프로필"
+
+#: kara/templates/includes/nav.html:129
+msgid "Logout"
+msgstr "로그아웃"
 
 #: kara/templates/registration/email_confirmation.html:4
 #: kara/templates/registration/email_confirmation.html:6

--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -39,12 +39,11 @@
                 class="block rounded bg-kara-very-shallow p-2.5 text-kara-deep transition md:hidden"
                 @click="showSidePanel = !showSidePanel"
                 >
-                <span class="sr-only">Toggle menu</span>
-                <div class="burger-menu" :class="{ 'active': showSidePanel }">
-                    <span></span>
-                    <span></span>
-                    <span></span>
-                </div>
+                    <div class="burger-menu" :class="{ 'active': showSidePanel }">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </div>
                 </button>
                 <div 
                 x-cloak 
@@ -71,23 +70,69 @@
                                 {% trans 'My Wedding Expenses' %}
                                 </a>
                             </li>
-                            <li>
-                            </li>
                         </ul>
                         <a class="block w-full py-3 mt-10 bg-kara-strong text-white text-center transition-color duration-500 border rounded-lg border-kara-strong hover:bg-white hover:text-kara-strong" role="button" href="{% url 'login' %}">{% trans 'Get started!' %}</a>
                     </div>
                 </div>
-                {% else %}
+            </div>
+            {% else %}
+            <div class="relative block" x-data="{ showSidePanel: false }">
                 <button
                 class="
                 w-[50px] h-[50px] rounded-full p-1 bg-transparent cursor-pointer 
                 overflow-hidden transition-all duration-500 ease-in-out
                 hover:ring-2 hover:ring-kara-deep
                 "
+                @click="showSidePanel = !showSidePanel"
                 >
                     <img alt="profile" src="{{ user.profile.bio_image.url }}"/>
                 </button>
-                {% endif %}
+                <div
+                x-cloak
+                x-show="showSidePanel"
+                x-transition:enter="transition ease-out duration-300"
+                x-transition:enter-start="opacity-0 transform translate-x-full"
+                x-transition:enter-end="opacity-100 transform translate-x-0"
+                class="fixed w-full inset-y-0 right-0 z-50 md:w-[420px] bg-white shadow-xl"
+                >
+                    <button
+                    id="closeSidePanel"
+                    type="button"
+                    class="absolute top-4 left-4 p-2 rounded-full hover:bg-kara-shallow transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-gray-300 flex items-center"
+                    @click="showSidePanel = false"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-kara-deep" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                        <span class="ml-1 text-kara-deep">{% trans 'Back' %}</span>
+                    </button>
+                    <div class="px-8 py-6">
+                        <div class="flex flex-col items-center justify-center">
+                            <div class="w-3/5 h-3/5 rounded-full bg-transparent">
+                                <img alt="profile" src="{{ user.profile.bio_image.url }}"/>
+                            </div>
+                            <h2 class="text-lg mt-6 text-center">
+                                {% blocktranslate with username=user.username %}Welcome, {{ username }}! How's your day going today 🙌{% endblocktranslate %}
+                            </h2>
+                        </div>
+                        <ul class="mt-6 text-lg">
+                            <li class="md:hidden py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
+                                <span class="mr-1">&gt;</span><a href="">{% trans 'Gift Tracker' %}</a>
+                            </li>
+                            <li class="md:hidden py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
+                                <span class="mr-1">&gt;</span><a href="">{% trans 'My Wedding Expenses' %}</a>
+                            </li>
+                            <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
+                                <span class="mr-1">&gt;</span><a href="">{% trans 'Profile' %}</a>
+                            </li>
+                            <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
+                                <span class="mr-1">&gt;</span><a href="">{% trans 'Logout' %}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## 작업 내용 
인증된 유저에게 렌더링되는 네비게이션바 사이드 패널을 추가했습니다.
인증된 유저가 네비게이션바에서 프로필을 클릭했을때 사이드 패널이 나타나며 사이드 패널은 미니 프로필의 역할과 다양한 세션 링크들을 제공합니다.
<img width="384" alt="Screenshot 2025-04-11 at 4 46 04 PM" src="https://github.com/user-attachments/assets/684c6054-b237-40be-b3cd-9ab5dd6b91d9" />

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/59

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
