### PR TITLE
Updated -- 프로필 페이지 업데이트.

### DIFF
--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -11,7 +11,12 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from .models import User
-from .widgets import FloatingLabelInput
+from .widgets import (
+    BooleanStateBlock,
+    FloatingLabelInput,
+    FloatingLabelTextarea,
+    ProfileFileInput,
+)
 
 
 class EmailVerificationCodeForm(forms.Form):
@@ -85,6 +90,40 @@ class CustomAuthenticationForm(AuthenticationForm):
             }
         ),
     )
+
+
+class UserProfileForm(forms.Form):
+
+    bio_image = forms.ImageField(
+        help_text=_("If you want to change profile image, click on the image!"),
+        widget=ProfileFileInput(attrs={"label": _("Profile Image")}),
+    )
+    username = forms.CharField(
+        widget=FloatingLabelInput(attrs={"label": _("Username"), "type": "text"})
+    )
+    email = forms.EmailField(
+        widget=FloatingLabelInput(attrs={"label": _("Email"), "type": "email"})
+    )
+    email_confirmed = forms.BooleanField(
+        required=False,
+        widget=BooleanStateBlock(
+            attrs={"label": _("Email Confirmed ?")},
+        ),
+    )
+    bio = forms.CharField(widget=FloatingLabelTextarea(attrs={"label": _("About Me")}))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        email_confirmed_state = kwargs["initial"]["email_confirmed"]
+        if email_confirmed_state:
+            self.fields["email_confirmed"].help_text = _(
+                "You have verified your email."
+            )
+        else:
+            self.fields["email_confirmed"].help_text = _(
+                "You have not verified your email yet. "
+                "Some features may be limited until you verify your email."
+            )
 
 
 class CustomUserCreationForm(UserCreationForm, forms.ModelForm):

--- a/kara/accounts/locale/ko/LC_MESSAGES/django.po
+++ b/kara/accounts/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-07 16:35+0900\n"
+"POT-Creation-Date: 2025-04-17 16:13+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,23 +46,85 @@ msgstr "확인을 위해 앞에서 입력한 비밀번호와 동일한 값을 �
 msgid "Username or Email"
 msgstr "아이디 또는 이메일"
 
-#: kara/accounts/forms.py:94
+#: kara/accounts/forms.py:93
+msgid "If you want to change profile image, click on the image!"
+msgstr "프로필 이미지를 변경하고 싶다면, 이미지를 클릭하세요!"
+
+#: kara/accounts/forms.py:95
+#: kara/accounts/templates/accounts/widgets/profile_file_input.html:3
+msgid "Profile Image"
+msgstr "프로필 이미지"
+
+#: kara/accounts/forms.py:100 kara/accounts/forms.py:135
 msgid "Username"
 msgstr "사용자 이름"
 
-#: kara/accounts/forms.py:100
+#: kara/accounts/forms.py:105 kara/accounts/forms.py:141
 msgid "Email"
 msgstr "이메일"
 
-#: kara/accounts/views.py:89
+#: kara/accounts/forms.py:110
+msgid "Email Confirmed ?"
+msgstr "이메일 인증 ?"
+
+#: kara/accounts/forms.py:115
+msgid "About Me"
+msgstr "자기소개"
+
+#: kara/accounts/forms.py:123
+msgid "You have verified your email."
+msgstr "이메일을 인증하셨습니다."
+
+#: kara/accounts/forms.py:126
+msgid ""
+"You have not verified your email yet. Some features may be limited until you "
+"verify your email."
+msgstr "아직 이메일을 인증하지 않았습니다. 이메일을 인증하지 않으면 일부 기능이 제한될 수 있습니다."
+
+#: kara/accounts/templates/accounts/profile.html:4
+#: kara/accounts/templates/accounts/profile.html:6
+msgid "Kara | Profile"
+msgstr "Kara | 프로필"
+
+#: kara/accounts/templates/accounts/profile.html:10
+#, python-format
+msgid "Welcome, %(username)s"
+msgstr "환영합니다, %(username)s"
+
+#: kara/accounts/templates/accounts/profile.html:20
+msgid "Profile"
+msgstr "프로필"
+
+#: kara/accounts/templates/accounts/profile.html:28
+msgid "Cash Gift Records"
+msgstr "축의금 기록"
+
+#: kara/accounts/templates/accounts/profile.html:36
+msgid "Wedding Expense Records"
+msgstr "결혼 비용 기록"
+
+#: kara/accounts/templates/accounts/profile.html:43
+msgid "Logout"
+msgstr "로그아웃"
+
+#: kara/accounts/templates/accounts/profile.html:63
+msgid "Save"
+msgstr "저장"
+
+#: kara/accounts/templates/accounts/widgets/profile_file_input.html:16
+#, python-format
+msgid "Selected image: %(value)s"
+msgstr "선택된 이미지: %(value)s"
+
+#: kara/accounts/views.py:90
 msgid "Email verification is complete!"
 msgstr "이메일 인증이 완료되었습니다!"
 
-#: kara/accounts/views.py:121
+#: kara/accounts/views.py:122
 msgid "The email verification code has been resent."
 msgstr "이메일 인증 코드가 다시 전송되었습니다."
 
-#: kara/accounts/views.py:140
+#: kara/accounts/views.py:141
 msgid ""
 "Your registration was successful. Please check your email provided for a "
 "verification code."

--- a/kara/accounts/templates/accounts/profile.html
+++ b/kara/accounts/templates/accounts/profile.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% load i18n widget_tweaks %}
+
+{% block title %}{% trans 'Kara | Profile' %}{% endblock %}
+
+{% block meta_title %}{% trans 'Kara | Profile' %}{% endblock %}
+
+{% block content %}
+<main class="my-12">
+    <h1 class="my-10 text-4xl text-center">{% blocktranslate with username=user.username %}Welcome, {{ username }}{% endblocktranslate %}</h1>
+    <div class="border-2 border-kara-strong rounded-lg" x-data="{ activeTab: 'profile' }">
+        <div class="flex flex-row">
+            <div class="w-[30%] border-r-2 border-kara-strong">
+                <ul class="text-base text-center">
+                    <li
+                    class="border-b-2 border-kara-strong text-kara-strong hover:text-white hover:bg-kara-shallow transition-color duration-300"
+                    :class="activeTab === 'profile' ? 'bg-kara-shallow text-white' : ''"
+                    >
+                        <button class="py-6 w-full" @click="activeTab = 'profile'">
+                            {% trans 'Profile' %}
+                        </button>
+                    </li>
+                    <li
+                    class="border-b-2 border-kara-strong text-kara-strong hover:text-white hover:bg-kara-shallow transition-color duration-300"
+                    :class="activeTab === 'cashGiftRecords' ? 'bg-kara-shallow text-white' : ''"
+                    >
+                        <button class="py-6 w-full" @click="activeTab = 'cashGiftRecords'">
+                            {% trans 'Cash Gift Records' %}
+                        </button>
+                    </li>
+                    <li
+                    class="border-b-2 border-kara-strong text-kara-strong hover:text-white hover:bg-kara-shallow transition-color duration-300"
+                    :class="activeTab === 'weddingExpenseRecords' ? 'bg-kara-shallow text-white' : ''"
+                    >
+                        <button class="py-6 w-full" @click="activeTab = 'weddingExpenseRecords'">
+                            {% trans 'Wedding Expense Records' %}
+                        </button>
+                    </li>
+                    <li
+                    class="border-b-2 border-kara-strong text-kara-strong hover:text-white hover:bg-kara-shallow transition-color duration-300"
+                    >
+                        <button class="py-6 w-full">
+                            {% trans 'Logout' %}
+                        </button>
+                    </li>
+                </ul>
+            </div>
+            <div class="w-[70%] flex flex-col items-center justify-center">
+                <div class="w-full px-8" x-show="activeTab === 'profile'">
+                    <form method="post">
+                        {% csrf_token %}
+                        {% for field in form %}
+                            {% if field|field_type == 'imagefield' %}
+                                <div class="flex flex-col items-center justify-center my-4">
+                                    {{ field.as_field_group }}
+                                </div>
+                            {% else %}
+                                <div class="field-container py-6">
+                                    {{ field.as_field_group }}
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                            <button class="
+                            block py-4 my-6 bg-red-200 w-1/3 bg-kara-strong rounded-lg text-white transition-color duration-500 mx-auto
+                            hover:bg-kara-deep
+                            "
+                            type="submit"
+                            >{% trans 'Save' %}</button>
+                    </form>
+                </div>
+                <div x-show="activeTab === 'cashGiftRecords'">
+                    <h1>Comming Soon! - Cash Gift Records</h1>
+                </div>
+                <div x-show="activeTab === 'weddingExpenseRecords'">
+                    <h1>Comming Soon! - Wedding Expense Records </h1>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+{% endblock %}

--- a/kara/accounts/templates/accounts/widgets/boolean_state_block.html
+++ b/kara/accounts/templates/accounts/widgets/boolean_state_block.html
@@ -1,0 +1,23 @@
+{% load i18n %}
+<div class="
+    flex flex-start items-center p-4 border-2 rounded-lg
+    {% if widget.attrs.state == True %}border-green-700 bg-green-700/50{% else %}border-red-700 bg-red-700/50{% endif %}
+    "
+    >
+    <label
+    class="text-white mr-2"
+    >
+    {{ widget.attrs.label }}
+    </label>
+    {% if widget.attrs.state == True %}
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5 13L9 17L19 7" stroke="#28a745" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+    </svg>
+    {% else %}
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M18 6L6 18" stroke="#dc3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M6 6L18 18" stroke="#dc3545" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+    </svg>
+    {% endif %}
+</div>
+

--- a/kara/accounts/templates/accounts/widgets/floating_label_textarea.html
+++ b/kara/accounts/templates/accounts/widgets/floating_label_textarea.html
@@ -1,17 +1,15 @@
 <div class="relative">
-    <input
+    <textarea
         id="{{ widget.name }}"
-        type="{{ widget.type }}"
-        name="{{ widget.name }}"
-        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
-        {% include "django/forms/widgets/attrs.html" %}
+        name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}
         class="
-        block w-full px-2.5 pb-2.5 pt-4 text-lg text-gray-900 bg-transparent rounded-lg border-2 border-kara-shallow appearance-none
+        block w-full h-40 px-2.5 pb-2.5 pt-4 text-lg text-gray-900 bg-transparent rounded-lg border-2 border-kara-shallow appearance-none resize-none
         dark:text-white dark:border-gray-600 dark:focus:border-blue-500
         focus:outline-none focus:ring-0 focus:border-kara-strong peer
         "
         placeholder=" "
     >
+    {% if widget.value %}{{ widget.value }}{% endif %}</textarea>
     <label
         for="{{ widget.name }}"
         class="

--- a/kara/accounts/templates/accounts/widgets/profile_file_input.html
+++ b/kara/accounts/templates/accounts/widgets/profile_file_input.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+
+<label class="my-4 text-kara-deep">{% trans 'Profile Image' %}</label>
+<div class="relative w-64 h-64 rounded-full overflow-hidden ring-2 ring-kara-shallow hover:ring-4 duration-500 transition-all">
+    <input
+    type={{ widget.type }}
+    name="{{ widget.name }}"
+    id="image-input"
+    class="opacity-0 absolute inset-0 w-full h-full cursor-pointer z-10"
+    {% include "django/forms/widgets/attrs.html" %}
+    >
+    <div class="w-full h-full p-10">
+      <img id="profile-bio-image" alt="profile-bio-image" src="{{ widget.value.url }}"/>
+    </div>
+</div>
+<div class="text-sm mt-2">{% blocktranslate with value=widget.value %}Selected image: {{ value }}{% endblocktranslate %}</div>
+<script>
+document.getElementById('image-input').addEventListener('change', function (event) {
+  const input = event.target;
+  const preview = document.getElementById('profile-bio-image');
+
+  if (input.files && input.files[0]) {
+      const reader = new FileReader();
+      console.log(input.files[0].name)
+      reader.onload = function (e) {
+          preview.src = e.target.result;
+      }
+      reader.readAsDataURL(input.files[0]);
+  }
+});
+</script>

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -5,6 +5,7 @@ from . import views
 urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),
     path("signup/", views.SignupView.as_view(), name="signup"),
+    path("profile/", views.ProfileView.as_view(), name="profile"),
     path(
         "email/confirmation/",
         views.EmailConfirmationView.as_view(),

--- a/kara/accounts/views.py
+++ b/kara/accounts/views.py
@@ -18,6 +18,7 @@ from .forms import (
     CustomAuthenticationForm,
     CustomUserCreationForm,
     EmailVerificationCodeForm,
+    UserProfileForm,
 )
 from .models import User
 
@@ -148,3 +149,21 @@ class SignupView(FormView):
         login(self.request, user)
         send_user_confirmation_email(self.request, user)
         return super().form_valid(form)
+
+
+@method_decorator(login_required, name="dispatch")
+class ProfileView(FormView):
+    template_name = "accounts/profile.html"
+    form_class = UserProfileForm
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        user = self.request.user
+        kwargs["initial"] = {
+            "username": user.username,
+            "email": user.email,
+            "bio": user.profile.bio,
+            "bio_image": user.profile.bio_image,
+            "email_confirmed": user.profile.email_confirmed,
+        }
+        return kwargs

--- a/kara/accounts/widgets.py
+++ b/kara/accounts/widgets.py
@@ -1,5 +1,22 @@
-from django.forms.widgets import Input
+from django.forms.widgets import CheckboxInput, ClearableFileInput, Input, Textarea
 
 
 class FloatingLabelInput(Input):
     template_name = "accounts/widgets/floating_label_input.html"
+
+
+class FloatingLabelTextarea(Textarea):
+    template_name = "accounts/widgets/floating_label_textarea.html"
+
+
+class BooleanStateBlock(CheckboxInput):
+    template_name = "accounts/widgets/boolean_state_block.html"
+
+    def render(self, name, value, attrs=None, renderer=None):
+        state = bool(value)
+        attrs["state"] = state
+        return super().render(name, value, attrs, renderer)
+
+
+class ProfileFileInput(ClearableFileInput):
+    template_name = "accounts/widgets/profile_file_input.html"

--- a/kara/locale/ko/LC_MESSAGES/django.po
+++ b/kara/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-11 16:38+0900\n"
+"POT-Creation-Date: 2025-04-17 16:13+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgid "My Wedding Expenses"
 msgstr "나의 결혼 비용"
 
 #: kara/templates/includes/nav.html:31
-#: kara/templates/registration/login.html:32
+#: kara/templates/registration/login.html:34
 msgid "Login"
 msgstr "로그인"
 
@@ -67,11 +67,11 @@ msgstr "로그아웃"
 msgid "Email Confirmation | Kara "
 msgstr "이메일 확인 | Kara"
 
-#: kara/templates/registration/email_confirmation.html:11
+#: kara/templates/registration/email_confirmation.html:13
 msgid "Please check your inbox!"
 msgstr "이메일을 확인해 주세요!"
 
-#: kara/templates/registration/email_confirmation.html:12
+#: kara/templates/registration/email_confirmation.html:14
 #, python-format
 msgid ""
 "To complete your registration, please enter the 6-digit code sent to <span "
@@ -80,15 +80,15 @@ msgstr ""
 "회원가입을 완료하려면 <span class=\"text-kara-deep\">%(email)s</span>로 전송"
 "된 6자리 인증 코드를 입력해 주세요."
 
-#: kara/templates/registration/email_confirmation.html:31
+#: kara/templates/registration/email_confirmation.html:33
 msgid "Resend Code"
 msgstr "인증 코드 재전송"
 
-#: kara/templates/registration/email_confirmation.html:43
+#: kara/templates/registration/email_confirmation.html:45
 msgid "Verify Code"
 msgstr "코드 확인"
 
-#: kara/templates/registration/email_confirmation.html:47
+#: kara/templates/registration/email_confirmation.html:49
 msgid "I'll confirm later!"
 msgstr "나중에 인증할게요!"
 
@@ -97,7 +97,7 @@ msgstr "나중에 인증할게요!"
 msgid "Login | kara"
 msgstr "로그인 | Kara"
 
-#: kara/templates/registration/login.html:20
+#: kara/templates/registration/login.html:22
 #, python-format
 msgid "Don't have an account you? %(link)ssignup%(end_link)s"
 msgstr "아직 계정이 없나요? %(link)s회원가입%(end_link)s"
@@ -107,15 +107,15 @@ msgstr "아직 계정이 없나요? %(link)s회원가입%(end_link)s"
 msgid "Registration | Kara"
 msgstr "회원가입 | Kara"
 
-#: kara/templates/registration/signup.html:11
+#: kara/templates/registration/signup.html:13
 msgid "Registration"
 msgstr "회원가입"
 
-#: kara/templates/registration/signup.html:19
+#: kara/templates/registration/signup.html:21
 #, python-format
 msgid "Already have an account? Then please %(link)ssign in%(end_link)s."
 msgstr "이미 계정이 있으신가요? 그렇다면 %(link)s로그인%(end_link)s 해주세요."
 
-#: kara/templates/registration/signup.html:32
+#: kara/templates/registration/signup.html:34
 msgid "Signup"
 msgstr "가입하기"

--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -123,7 +123,7 @@
                                 <span class="mr-1">&gt;</span><a href="">{% trans 'My Wedding Expenses' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
-                                <span class="mr-1">&gt;</span><a href="">{% trans 'Profile' %}</a>
+                                <span class="mr-1">&gt;</span><a href="{% url 'profile' %}">{% trans 'Profile' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
                                 <span class="mr-1">&gt;</span><a href="">{% trans 'Logout' %}</a>


### PR DESCRIPTION
## 작업 내용
<img width="646" alt="Screenshot 2025-04-17 at 4 39 46 PM" src="https://github.com/user-attachments/assets/45e6ef58-4c00-4756-84ff-a8c70db44965" />
프로필 페이지를 추가했습니다.
현재 프로필 페이지는 수정기능을 제공하지 않습니다.
추가로 이메일 인증이 안된 유저에게는 이메일 인증할 수 있도록 리디렉션 버튼이 필요합니다.
프로필 이미지설정 또한 디테일한 동작이 필요합니다.(이미지 크기를 자르는등.. 클라이언트가 특정 이미지 부분만 선택하는 등..)

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/68

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
