### PR TITLE
Updated -- 프로필 페이지 이메일 인증하지 않은 유저에게 렌더링되는 이메일 인증버튼 추가.

### DIFF
--- a/kara/accounts/locale/ko/LC_MESSAGES/django.po
+++ b/kara/accounts/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-17 16:13+0900\n"
+"POT-Creation-Date: 2025-04-18 10:42+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,48 +18,48 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: kara/accounts/forms.py:19
+#: kara/accounts/forms.py:24
 msgid "Confirmation Code"
 msgstr "인증 코드"
 
-#: kara/accounts/forms.py:21
+#: kara/accounts/forms.py:26
 msgid "Enter the 6-digit verification code sent to your email."
 msgstr "이메일로 전송된 6자리 인증 코드를 입력하세요."
 
-#: kara/accounts/forms.py:37
+#: kara/accounts/forms.py:42
 msgid "The verification code does not match."
 msgstr "인증 코드가 일치하지 않습니다."
 
-#: kara/accounts/forms.py:43 kara/accounts/forms.py:82
+#: kara/accounts/forms.py:48 kara/accounts/forms.py:87
 msgid "Password"
 msgstr "비밀번호"
 
-#: kara/accounts/forms.py:43
+#: kara/accounts/forms.py:48
 msgid "Password confirmation"
 msgstr "비밀번호 확인"
 
-#: kara/accounts/forms.py:67
+#: kara/accounts/forms.py:72
 msgid "Enter the same password as before, for verification."
 msgstr "확인을 위해 앞에서 입력한 비밀번호와 동일한 값을 입력하세요."
 
-#: kara/accounts/forms.py:75
+#: kara/accounts/forms.py:80
 msgid "Username or Email"
 msgstr "아이디 또는 이메일"
 
-#: kara/accounts/forms.py:93
+#: kara/accounts/forms.py:98
 msgid "If you want to change profile image, click on the image!"
 msgstr "프로필 이미지를 변경하고 싶다면, 이미지를 클릭하세요!"
 
-#: kara/accounts/forms.py:95
+#: kara/accounts/forms.py:99
 #: kara/accounts/templates/accounts/widgets/profile_file_input.html:3
 msgid "Profile Image"
 msgstr "프로필 이미지"
 
-#: kara/accounts/forms.py:100 kara/accounts/forms.py:135
+#: kara/accounts/forms.py:102 kara/accounts/forms.py:133
 msgid "Username"
 msgstr "사용자 이름"
 
-#: kara/accounts/forms.py:105 kara/accounts/forms.py:141
+#: kara/accounts/forms.py:105 kara/accounts/forms.py:139
 msgid "Email"
 msgstr "이메일"
 
@@ -67,19 +67,21 @@ msgstr "이메일"
 msgid "Email Confirmed ?"
 msgstr "이메일 인증 ?"
 
-#: kara/accounts/forms.py:115
+#: kara/accounts/forms.py:113
 msgid "About Me"
 msgstr "자기소개"
 
-#: kara/accounts/forms.py:123
+#: kara/accounts/forms.py:120
 msgid "You have verified your email."
 msgstr "이메일을 인증하셨습니다."
 
-#: kara/accounts/forms.py:126
+#: kara/accounts/forms.py:124
 msgid ""
 "You have not verified your email yet. Some features may be limited until you "
 "verify your email."
-msgstr "아직 이메일을 인증하지 않았습니다. 이메일을 인증하지 않으면 일부 기능이 제한될 수 있습니다."
+msgstr ""
+"아직 이메일을 인증하지 않았습니다. 이메일을 인증하지 않으면 일부 기능이 제한"
+"될 수 있습니다."
 
 #: kara/accounts/templates/accounts/profile.html:4
 #: kara/accounts/templates/accounts/profile.html:6
@@ -107,7 +109,12 @@ msgstr "결혼 비용 기록"
 msgid "Logout"
 msgstr "로그아웃"
 
-#: kara/accounts/templates/accounts/profile.html:63
+#: kara/accounts/templates/accounts/profile.html:61
+#| msgid "Confirmation Code"
+msgid "Confirm Now!"
+msgstr "지금 인증할래요!"
+
+#: kara/accounts/templates/accounts/profile.html:75
 msgid "Save"
 msgstr "저장"
 

--- a/kara/accounts/templates/accounts/profile.html
+++ b/kara/accounts/templates/accounts/profile.html
@@ -54,6 +54,17 @@
                                 <div class="flex flex-col items-center justify-center my-4">
                                     {{ field.as_field_group }}
                                 </div>
+                            {% elif field.name == 'email_confirmed' %}
+                                <div class="field-container py-6">
+                                    {{ field.as_field_group }}
+                                    {% if field.value == False %}
+                                    <a class="
+                                    block mt-4 py-4 w-2/6 text-center text-kara-deep border-2 border-kara-strong rounded-lg duration-500 transition-color ml-auto
+                                    hover:text-white hover:bg-kara-deep
+                                    "
+                                    role="button" href="{% url 'email_confirmation_resend' %}">{% trans 'Confirm Now!' %}</a>
+                                    {% endif %}
+                                </div>
                             {% else %}
                                 <div class="field-container py-6">
                                     {{ field.as_field_group }}

--- a/kara/accounts/tests/test_profile_view.py
+++ b/kara/accounts/tests/test_profile_view.py
@@ -1,0 +1,45 @@
+import pytest
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+from playwright.sync_api import expect
+
+from kara.accounts.factories import UserFactory
+
+
+class ProfileViewTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            username="cheeze123", email="cheeze123@cake.com", password="password"
+        )
+        cls.url = reverse("profile")
+
+    def setUp(self):
+        self.client.force_login(self.user)
+
+    def test_email_confirm_field_help_text_template_render(self):
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            "You have not verified your email yet. "
+            "Some features may be limited until you verify your email.",
+        )
+        self.user.profile.email_confirmed = True
+        self.user.profile.save()
+        response = self.client.get(self.url)
+        self.assertContains(response, "You have verified your email.")
+
+
+@pytest.mark.playwright
+class TestPlaywright:
+
+    def test_click_email_confirmation_button(self, auth_page, live_server):
+        auth_page.goto(live_server.url + reverse("profile"))
+        auth_page.get_by_role("button", name="Confirm Now!").click()
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == "Kara Email Confirmation"
+        assert "Hello tester, Welcome to Kara!" in mail.outbox[0].body
+        expect(auth_page).to_have_title("Email Confirmation | Kara")
+        expect(auth_page).to_have_url(live_server.url + reverse("email_confirmation"))

--- a/kara/accounts/views.py
+++ b/kara/accounts/views.py
@@ -115,7 +115,7 @@ class EmailConfirmationView(FormView):
 
 
 class ResendEmailVerificationCodeView(LoginRequiredMixin, View):
-    def post(self, request):
+    def get(self, request):
         user = request.user
         send_user_confirmation_email(request, user)
         messages.add_message(

--- a/kara/templates/registration/email_confirmation.html
+++ b/kara/templates/registration/email_confirmation.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 {% load i18n widget_tweaks %}
 
-{% block title %}{% translate "Email Confirmation | Kara "%}{% endblock %}
+{% block title %}{% translate "Email Confirmation | Kara" %}{% endblock %}
 
-{% block meta_title %}{% translate "Email Confirmation | Kara "%}{% endblock %}
+{% block meta_title %}{% translate "Email Confirmation | Kara" %}{% endblock %}
 
 {% block navbar %}{% endblock %}
 


### PR DESCRIPTION
## 작업 내용
<img width="650" alt="Screenshot 2025-04-18 at 5 06 26 PM" src="https://github.com/user-attachments/assets/5c2d89a2-b1c6-42dc-848b-4582284a6224" />

이메일 인증을 수행하지 않은 유저에게 "지금 인증할래요" 버튼이 렌더링되도록 추가했습니다.
해당 버튼은 이메일 인증코드를 발급하고 이메일 인증페이지로 리디렉션합니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/70

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
