### PR TITLE
Updated -- 이메일 인증페이지에서 인증코드 재발급 버튼을 링크로 전환.

### DIFF
--- a/kara/accounts/tests/test_confirm_email_verification_code_view.py
+++ b/kara/accounts/tests/test_confirm_email_verification_code_view.py
@@ -1,4 +1,3 @@
-from django.core import mail
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -42,7 +41,7 @@ class ConfirmEmailVerificationCodeViewTests(TestCase):
     def test_email_verification_success(self):
         response = self.client.post(
             self.url,
-            data={"code": self.verification_code, "action_confirm": "1"},
+            data={"code": self.verification_code},
             follow=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -53,25 +52,9 @@ class ConfirmEmailVerificationCodeViewTests(TestCase):
     def test_email_verification_fail(self):
         response = self.client.post(
             self.url,
-            data={"code": 123456, "action_confirm": "1"},
+            data={"code": 123456},
             follow=True,
         )
         self.assertContains(
             response, "<li>The verification code does not match.</li>", html=True
-        )
-
-    def test_resend_email_confirmation_code(self):
-        mail_cnt = len(mail.outbox)
-        response = self.client.post(
-            self.url,
-            data={"action_resend": "1"},
-            follow=True,
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(mail.outbox), mail_cnt + 1)
-        self.assertEqual(mail.outbox[-1].subject, "Kara Email Confirmation")
-        self.assertIn(
-            "Please enter the 6-digit email verification code on the "
-            "email verification page.",
-            mail.outbox[-1].body,
         )

--- a/kara/accounts/tests/test_resend_email_confirmation_view.py
+++ b/kara/accounts/tests/test_resend_email_confirmation_view.py
@@ -16,13 +16,13 @@ class ResendEmailConfirmationViewTests(TestCase):
         self.client.force_login(self.user)
 
     def test_redirect_template_render(self):
-        response = self.client.post(self.url, {}, follow=True)
+        response = self.client.get(self.url, {}, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Please check your inbox!")
         self.assertContains(response, "mango@farm.com")
 
     def test_resend_email(self):
-        self.client.post(self.url, {}, follow=True)
+        self.client.get(self.url, {}, follow=True)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "Kara Email Confirmation")
         self.assertIn(

--- a/kara/accounts/views.py
+++ b/kara/accounts/views.py
@@ -73,16 +73,6 @@ class EmailConfirmationView(FormView):
         self.verification = request.session.get(PENDING_EMAIL_CONFIRMATION_SESSION_KEY)
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
-        res = None
-        if request.method == "POST":
-            if "action_resend" in request.POST:
-                view = ResendEmailVerificationCodeView.as_view()
-                res = view(request)
-            elif "action_confirm" in request.POST:
-                res = super().post(request, *args, **kwargs)
-        return res
-
     def get_success_url(self):
         messages.add_message(
             self.request,

--- a/kara/templates/registration/email_confirmation.html
+++ b/kara/templates/registration/email_confirmation.html
@@ -22,21 +22,19 @@
                         </div>
                     {% endfor %}
                     <div class="pl-1 flex mt-4 mb-2">
-                        <button 
-                        type="submit"
-                        name="action_resend"
+                        <a
+                        href="{% url 'email_confirmation_resend' %}"
                         class="
                         resend-code text-kara-strong hover:text-kara-deep transition-colors duration-500 mr-4
                         disabled:text-kara-shallow disabled:cursor-default disabled:opacity-80
                         "
                         >
                         {% translate "Resend Code" %}
-                        </button>
+                        </a>
                         <div class="timer"></div>
                     </div>
                     <button
                     type="submit"
-                    name="action_confirm"
                     class="
                     w-full text-lg bg-kara-shallow py-3 rounded-lg text-white transition-colors duration-500
                     hover:bg-kara-very-shallow hover:text-kara-strong


### PR DESCRIPTION
## 작업 내용
이메일 인증페이지에서 인증코드 재발급과 인증코드 확인 기능이 버튼으로 되어있어 action을 전달하여 로직을 분기하는 식으로 처리했습니다.
하지만 인증코드 재발급은 데이터 전달이 필요없기 때문에 버튼이아닌 링크형태로 제공되어야합니다.
그렇기 때문에 이메일 인증페이지에서 인증코드 재발급버튼을 링크로 전환했습니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/75

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
