### PR TITLE
Updated -- 프로필 URL을 동적URL을 사용하도록 변경.

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -5,6 +5,8 @@ from .base import *
 # LANGUAGE
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
+DEBUG = False
+
 LANGUAGE_CODE = "en-us"
 
 SECRET_KEY = "TEST**123456789**TEST"
@@ -13,3 +15,5 @@ DATABASES["default"] = dj_database_url.config(
     conn_max_age=600,
     conn_health_checks=True,
 )
+
+LOGGING = {}

--- a/kara/accounts/tests/test_profile_view.py
+++ b/kara/accounts/tests/test_profile_view.py
@@ -15,7 +15,7 @@ class ProfileViewTests(TestCase):
             username="cheeze123", email="cheeze123@cake.com", password="password"
         )
         cls.profile = cls.user.profile
-        cls.url = reverse("profile")
+        cls.url = reverse("profile", args=(cls.user.username,))
 
     def setUp(self):
         self.client.force_login(self.user)
@@ -51,6 +51,20 @@ class ProfileViewTests(TestCase):
         )
         self.profile.refresh_from_db()
         self.assertFalse(self.profile.email_confirmed)
+
+    def test_update_profile_another_user(self):
+        user = UserFactory(
+            username="choco123", email="choco123@cake.com", password="password"
+        )
+        self.client.force_login(user)
+        response = self.client.post(
+            self.url, {"bio": "Edit another user's profile!!"}, follow=True
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_profile_from_not_exist_user(self):
+        response = self.client.get(reverse("profile", args=("unknown",)))
+        self.assertEqual(response.status_code, 404)
 
 
 @pytest.mark.playwright

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),
     path("signup/", views.SignupView.as_view(), name="signup"),
     path("logout/", LogoutView.as_view(next_page="home"), name="logout"),
-    path("profile/", views.ProfileView.as_view(), name="profile"),
+    path("profile/<str:username>/", views.ProfileView.as_view(), name="profile"),
     path(
         "email/confirmation/",
         views.EmailConfirmationView.as_view(),

--- a/kara/accounts/views.py
+++ b/kara/accounts/views.py
@@ -5,14 +5,16 @@ from django.contrib import messages
 from django.contrib.auth import login, views as django_views
 from django.contrib.auth.decorators import login_not_required, login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
+from django.http import Http404
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.crypto import get_random_string
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import FormView, View
+from django.views.generic import FormView, UpdateView, View
 
 from .forms import (
     CustomAuthenticationForm,
@@ -20,7 +22,7 @@ from .forms import (
     EmailVerificationCodeForm,
     UserProfileForm,
 )
-from .models import User
+from .models import User, UserProfile
 
 PENDING_EMAIL_CONFIRMATION_SESSION_KEY = "pending_email_confirmation"
 
@@ -141,14 +143,35 @@ class SignupView(FormView):
         return super().form_valid(form)
 
 
-@method_decorator(login_required, name="dispatch")
-class ProfileView(FormView):
+class ProfileView(UpdateView):
     template_name = "accounts/profile.html"
     form_class = UserProfileForm
+    model = UserProfile
+    url_kwarg = "username"
+
+    def post(self, request, *args, **kwargs):
+        obj = self.get_object()
+        if obj.user != request.user:
+            raise PermissionDenied(
+                "You do not have permission to edit %s's profile" % obj.user.username
+            )
+        return super().post(request, *args, **kwargs)
 
     def get_object(self):
-        user = self.request.user
-        return user, user.profile
+        queryset = self.get_queryset()
+        username = self.kwargs.get(self.url_kwarg)
+        if username is None:
+            raise AttributeError(
+                "%s must be called with a %s parameter in the URLconf."
+                % (self.__class__.__name__, self.url_kwarg)
+            )
+        queryset = queryset.filter(user__username=username)
+        try:
+            # Get the single item from the filtered queryset
+            obj = queryset.get()
+        except queryset.model.DoesNotExist:
+            raise Http404("%s user does not exist." % username)
+        return obj
 
     def get_success_url(self):
         messages.add_message(
@@ -156,7 +179,7 @@ class ProfileView(FormView):
             messages.INFO,
             _("Your profile has been updated!"),
         )
-        return reverse("profile")
+        return reverse("profile", args=(self.kwargs.get(self.url_kwarg),))
 
     def form_valid(self, form):
         user = form.save()
@@ -173,7 +196,8 @@ class ProfileView(FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        user, profile = self.get_object()
+        profile = self.get_object()
+        user = profile.user
         kwargs["instance"] = user
         kwargs["initial"] = {
             "username": user.username,

--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -123,7 +123,7 @@
                                 <span class="mr-1">&gt;</span><a href="">{% trans 'My Wedding Expenses' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
-                                <span class="mr-1">&gt;</span><a href="{% url 'profile' %}">{% trans 'Profile' %}</a>
+                                <span class="mr-1">&gt;</span><a href="{% url 'profile' user.username %}">{% trans 'Profile' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
                                 <form method="post" action="{% url 'logout' %}">


### PR DESCRIPTION
## 작업 내용
프로필 URL을 동적URL로 변경하여 `username`을 통해 다른 유저의 정보를 가져올 수 있도록 변경했습니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/81

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
