### PR TITLE
Reverted -- 동적 URL을 사용하는 프로필 페이지를 다시 정적 URL을 사용하다록 되돌림.

### DIFF
--- a/kara/accounts/templates/accounts/forms/field.html
+++ b/kara/accounts/templates/accounts/forms/field.html
@@ -1,0 +1,7 @@
+{% load widget_tweaks %}
+{{ field|add_class:"block w-full px-2.5 pb-2.5 pt-4 text-lg text-gray-900 bg-transparent rounded-lg border-2 border-kara-shallow appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-kara-strong peer caret-transparent select-none" }}
+{% if field.errors %}
+    <ul class="text-sm mt-2 pl-1 text-red-700 w-inherit">{% for error in field.errors %}<li>{{ error }}</li>{% endfor %}</ul>
+{% elif is_owner and field.help_text %}
+    <div class="text-sm helptext mt-2 pl-1"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</div>
+{% endif %}

--- a/kara/accounts/templatetags/profile_field.py
+++ b/kara/accounts/templatetags/profile_field.py
@@ -1,0 +1,11 @@
+from django.template import Library
+
+register = Library()
+
+
+@register.inclusion_tag("accounts/forms/field.html")
+def render_field(field, is_owner=False):
+    return {
+        "field": field,
+        "is_owner": is_owner,
+    }

--- a/kara/accounts/tests/test_profile_view.py
+++ b/kara/accounts/tests/test_profile_view.py
@@ -15,7 +15,7 @@ class ProfileViewTests(TestCase):
             username="cheeze123", email="cheeze123@cake.com", password="password"
         )
         cls.profile = cls.user.profile
-        cls.url = reverse("profile", args=(cls.user.username,))
+        cls.url = reverse("profile")
 
     def setUp(self):
         self.client.force_login(self.user)
@@ -51,20 +51,6 @@ class ProfileViewTests(TestCase):
         )
         self.profile.refresh_from_db()
         self.assertFalse(self.profile.email_confirmed)
-
-    def test_update_profile_another_user(self):
-        user = UserFactory(
-            username="choco123", email="choco123@cake.com", password="password"
-        )
-        self.client.force_login(user)
-        response = self.client.post(
-            self.url, {"bio": "Edit another user's profile!!"}, follow=True
-        )
-        self.assertEqual(response.status_code, 403)
-
-    def test_get_profile_from_not_exist_user(self):
-        response = self.client.get(reverse("profile", args=("unknown",)))
-        self.assertEqual(response.status_code, 404)
 
 
 @pytest.mark.playwright

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),
     path("signup/", views.SignupView.as_view(), name="signup"),
     path("logout/", LogoutView.as_view(next_page="home"), name="logout"),
-    path("profile/<str:username>/", views.ProfileView.as_view(), name="profile"),
+    path("profile/", views.ProfileView.as_view(), name="profile"),
     path(
         "email/confirmation/",
         views.EmailConfirmationView.as_view(),

--- a/kara/templates/includes/nav.html
+++ b/kara/templates/includes/nav.html
@@ -123,7 +123,7 @@
                                 <span class="mr-1">&gt;</span><a href="">{% trans 'My Wedding Expenses' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
-                                <span class="mr-1">&gt;</span><a href="{% url 'profile' user.username %}">{% trans 'Profile' %}</a>
+                                <span class="mr-1">&gt;</span><a href="{% url 'profile' %}">{% trans 'Profile' %}</a>
                             </li>
                             <li class="py-4 px-2 border-t-2 border-t-kara-shallow/60 hover:bg-kara-shallow hover:text-white transition-colors duration-300">
                                 <form method="post" action="{% url 'logout' %}">


### PR DESCRIPTION
## 작업 내용
f5c3fe4 --> 프로필 페이지에 동적 URL을 적용하는 커밋의 변경사항을 되돌렸습니다.

프로필 페이지에 동적 URL이 필요하지 않은것으로 결정되었습니다.

## 연관된 이슈
- X

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
