### PR TITLE
Updated -- 계정 삭제 기능 추가.

### DIFF
--- a/kara/accounts/forms.py
+++ b/kara/accounts/forms.py
@@ -15,6 +15,7 @@ from .widgets import (
     BooleanStateBlock,
     FloatingLabelInput,
     FloatingLabelTextarea,
+    KaraCheckbox,
     ProfileFileInput,
 )
 
@@ -182,3 +183,22 @@ class CustomUserCreationForm(UserCreationForm, forms.ModelForm):
                 password_validation.validate_password(password, self.instance)
             except ValidationError as error:
                 self.add_error("password1", error)
+
+
+class AccountDeleteForm(forms.Form):
+    confirm_irrecoverable = forms.BooleanField(
+        widget=KaraCheckbox(
+            attrs={
+                "label": _("Deleted accounts cannot be recovered."),
+            }
+        ),
+        required=True,
+    )
+    confirm_data_loss = forms.BooleanField(
+        widget=KaraCheckbox(
+            attrs={
+                "label": _("Deleting your account will permanently remove all data."),
+            }
+        ),
+        required=True,
+    )

--- a/kara/accounts/locale/ko/LC_MESSAGES/django.po
+++ b/kara/accounts/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-22 18:18+0900\n"
+"POT-Creation-Date: 2025-04-30 18:24+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,70 +18,94 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: kara/accounts/forms.py:24
+#: kara/accounts/forms.py:25
 msgid "Confirmation Code"
 msgstr "인증 코드"
 
-#: kara/accounts/forms.py:26
+#: kara/accounts/forms.py:27
 msgid "Enter the 6-digit verification code sent to your email."
 msgstr "이메일로 전송된 6자리 인증 코드를 입력하세요."
 
-#: kara/accounts/forms.py:42
+#: kara/accounts/forms.py:43
 msgid "The verification code does not match."
 msgstr "인증 코드가 일치하지 않습니다."
 
-#: kara/accounts/forms.py:48
+#: kara/accounts/forms.py:49
 msgid "If you want to change profile image, click on the image!"
 msgstr "프로필 이미지를 변경하고 싶다면, 이미지를 클릭하세요!"
 
-#: kara/accounts/forms.py:49
+#: kara/accounts/forms.py:50
 #: kara/accounts/templates/accounts/widgets/profile_file_input.html:3
 msgid "Profile Image"
 msgstr "프로필 이미지"
 
-#: kara/accounts/forms.py:52
+#: kara/accounts/forms.py:53
 msgid "About Me"
 msgstr "자기소개"
 
-#: kara/accounts/forms.py:57
+#: kara/accounts/forms.py:58
 msgid "Email Confirmed ?"
 msgstr "이메일 인증 ?"
 
-#: kara/accounts/forms.py:65 kara/accounts/forms.py:104
+#: kara/accounts/forms.py:66 kara/accounts/forms.py:105
 msgid "Password"
 msgstr "비밀번호"
 
-#: kara/accounts/forms.py:65
+#: kara/accounts/forms.py:66
 msgid "Password confirmation"
 msgstr "비밀번호 확인"
 
-#: kara/accounts/forms.py:89
+#: kara/accounts/forms.py:90
 msgid "Enter the same password as before, for verification."
 msgstr "확인을 위해 앞에서 입력한 비밀번호와 동일한 값을 입력하세요."
 
-#: kara/accounts/forms.py:97
+#: kara/accounts/forms.py:98
 msgid "Username or Email"
 msgstr "아이디 또는 이메일"
 
-#: kara/accounts/forms.py:124 kara/accounts/forms.py:146
+#: kara/accounts/forms.py:126 kara/accounts/forms.py:149
 msgid "Username"
 msgstr "사용자 이름"
 
-#: kara/accounts/forms.py:125 kara/accounts/forms.py:152
+#: kara/accounts/forms.py:128 kara/accounts/forms.py:155
 msgid "Email"
 msgstr "이메일"
 
-#: kara/accounts/forms.py:133
+#: kara/accounts/forms.py:136
 msgid "You have verified your email."
 msgstr "이메일을 인증하셨습니다."
 
-#: kara/accounts/forms.py:137
+#: kara/accounts/forms.py:140
 msgid ""
 "You have not verified your email yet. Some features may be limited until you "
 "verify your email."
 msgstr ""
 "아직 이메일을 인증하지 않았습니다. 이메일을 인증하지 않으면 일부 기능이 제한"
 "될 수 있습니다."
+
+#: kara/accounts/forms.py:192
+msgid "Deleted accounts cannot be recovered."
+msgstr "삭제된 계정은 복구할 수 없습니다."
+
+#: kara/accounts/forms.py:200
+msgid "Deleting your account will permanently remove all data."
+msgstr "계정을 삭제할 시 모든 데이터가 삭제됩니다."
+
+#: kara/accounts/templates/accounts/modal/delete_account_modal.html:14
+msgid "Delete Account"
+msgstr "계정 삭제"
+
+#: kara/accounts/templates/accounts/modal/delete_account_modal.html:16
+msgid "Do you really want to delete your account?"
+msgstr "정말로 계정을 삭제하시겠습니까?"
+
+#: kara/accounts/templates/accounts/modal/delete_account_modal.html:25
+msgid "※ To delete your account, please agree to all of the above statements."
+msgstr "※ 계정을 삭제하려면 위 사항에 모두 동의해주세요."
+
+#: kara/accounts/templates/accounts/modal/delete_account_modal.html:26
+msgid "Delete"
+msgstr "삭제"
 
 #: kara/accounts/templates/accounts/profile.html:4
 #: kara/accounts/templates/accounts/profile.html:6
@@ -109,11 +133,11 @@ msgstr "결혼 비용 기록"
 msgid "Logout"
 msgstr "로그아웃"
 
-#: kara/accounts/templates/accounts/profile.html:68
+#: kara/accounts/templates/accounts/profile.html:95
 msgid "Confirm Now!"
 msgstr "지금 인증할래요!"
 
-#: kara/accounts/templates/accounts/profile.html:82
+#: kara/accounts/templates/accounts/profile.html:109
 msgid "Save"
 msgstr "저장"
 
@@ -138,6 +162,10 @@ msgstr ""
 "회원가입이 완료되었습니다. 입력하신 이메일로 전송된 인증 코드를 확인해 주세"
 "요."
 
-#: kara/accounts/views.py:157
+#: kara/accounts/views.py:168
 msgid "Your profile has been updated!"
 msgstr "프로필이 업데이트 되었습니다!"
+
+#: kara/accounts/views.py:206
+msgid "Your account was successfully deleted."
+msgstr "계정이 성공적으로 삭제되었습니다."

--- a/kara/accounts/templates/accounts/modal/delete_account_modal.html
+++ b/kara/accounts/templates/accounts/modal/delete_account_modal.html
@@ -1,0 +1,37 @@
+{% extends "modal/base.html" %}
+{% load i18n %}
+<head>
+    <style>
+        .modal-container:hover {
+            color: black;
+        }
+
+        .danger-icon {
+            width: 20px;
+        }
+    </style>
+</head>
+{% block modal_name %}delete_account{% endblock %}
+{% block trigger %}<button class="py-6 w-full" @click="open = true">{% trans 'Delete Account' %}</button>{% endblock %}
+{% block header %}
+    <h3 class="modal-title text-lg text-red-600 font-bold flex flew-row">{% include "icons/danger.html" with extra_class="w-[20px] mr-2" %}{% translate 'Do you really want to delete your account?' %}</h3>
+{% endblock %}
+{% block content %}
+<div class="px-4">
+    <form method="post" action="{% url 'delete_account' %}">
+        {% csrf_token %}
+        <div class="my-4">
+            {% for field in form %}
+                <div class="{{ field.name }}-field-container">
+                    {{ field }}
+                    <ul class="text-sm text-left pl-4 text-red-700 w-inherit">{% for error in field.errors %}<li>{{ error }}</li>{% endfor %}</ul>
+                </div>
+            {% endfor %}
+        </div>
+        <p id="delete-account-form-help-text" class="my-4">{% translate '※ To delete your account, please agree to all of the above statements.' %}</p>
+        <button id="delete-account-button" type="submit" class="block py-4 w-1/3 bg-kara-strong rounded-lg text-white transition-color duration-500 mx-auto hover:bg-kara-deep">{% trans 'Delete' %}</button>
+    </form>
+</div>
+{% endblock %}
+{% block footer %}
+{% endblock %}

--- a/kara/accounts/templates/accounts/profile.html
+++ b/kara/accounts/templates/accounts/profile.html
@@ -46,6 +46,11 @@
                             </button>
                         </form>
                     </li>
+                    <li
+                    class="block border-b-2 border-kara-strong text-kara-strong hover:text-white hover:bg-kara-shallow transition-color duration-300"
+                    >
+                        {% include "accounts/modal/delete_account_modal.html" with form=account_delete_form modal_state=account_delete_modal_state %}
+                    </li>
                 </ul>
             </div>
             <div class="w-[70%] flex flex-col items-center justify-center">

--- a/kara/accounts/templates/accounts/widgets/checkbox.html
+++ b/kara/accounts/templates/accounts/widgets/checkbox.html
@@ -1,0 +1,18 @@
+<style>
+    input[type="checkbox"]:checked + label span:first-child {
+      background-color: #E38282;
+      border-color: #FFEEEE;
+    }
+</style>
+
+<div class="relative m-2 text-sm">
+    <input type="checkbox" id="{{ widget.name }}" name="{{ widget.name }}" class="peer absolute opacity-0 w-0 h-0 cursor-pointer" {% include "django/forms/widgets/attrs.html" %}>
+    <label for="{{ widget.name }}" class="flex items-center cursor-pointer select-none p-1.5 rounded transition-colors duration-200 hover:bg-kara-shallow hover:text-white focus:outline-none focus:ring-2 focus:ring-kara-deep peer-checked:bg-[#E38282] peer-checked:text-white">
+        <span class="relative w-5 h-5 border-2 border-kara-deep rounded bg-white mr-2 flex items-center justify-center peer-checked:bg-[#E38282] peer-checked:border-[#E38282]">
+        <svg class="absolute h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
+        </svg>
+        </span>
+        <span class="text-base font-sans">{{ widget.attrs.label }}</span>
+    </label>
+</div>

--- a/kara/accounts/tests/test_account_delete_view.py
+++ b/kara/accounts/tests/test_account_delete_view.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from kara.accounts.factories import UserFactory
+from kara.accounts.models import User
+
+
+class AccountDeleteViewTests(TestCase):
+
+    def setUp(self):
+        self.user = UserFactory(
+            username="tuna123", email="tuna123@ocean.com", password="password"
+        )
+        self.url = reverse("delete_account")
+        self.client.force_login(self.user)
+
+    def test_delete_account_success(self):
+        response = self.client.post(
+            self.url,
+            {
+                "confirm_irrecoverable": True,
+                "confirm_data_loss": True,
+            },
+        )
+        self.assertEqual(response.url, "/")
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(User.objects.filter(username="tuna123").exists())

--- a/kara/accounts/urls.py
+++ b/kara/accounts/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),
     path("signup/", views.SignupView.as_view(), name="signup"),
     path("logout/", LogoutView.as_view(next_page="home"), name="logout"),
+    path("delete/", views.AccountDeleteView.as_view(), name="delete_account"),
     path("profile/", views.ProfileView.as_view(), name="profile"),
     path(
         "email/confirmation/",

--- a/kara/accounts/widgets.py
+++ b/kara/accounts/widgets.py
@@ -20,3 +20,7 @@ class BooleanStateBlock(CheckboxInput):
 
 class ProfileFileInput(ClearableFileInput):
     template_name = "accounts/widgets/profile_file_input.html"
+
+
+class KaraCheckbox(CheckboxInput):
+    template_name = "accounts/widgets/checkbox.html"

--- a/kara/templates/icons/danger.html
+++ b/kara/templates/icons/danger.html
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" class="danger-icon {{ extra_class }}">
+    <circle cx="50" cy="50" r="45" fill="#ff3b30" />
+    <g fill="white">
+      <rect x="45" y="20" width="10" height="40" rx="5" ry="5" />
+      <circle cx="50" cy="75" r="5" />
+    </g>
+</svg>


### PR DESCRIPTION
## 작업 내용

계정 삭제 기능을 추가했습니다.

<img width="1039" alt="Screenshot 2025-04-30 at 6 32 13 PM" src="https://github.com/user-attachments/assets/ae25b122-3e08-45cc-9a21-2d8a045c4451" />

계정 삭제는 프로필페이지에서 버튼을 통해 접근할 수 있으며 클릭시 모달이 렌더링되고 모달에서 최종적으로 삭제 동의했을때 계정이 삭제됩니다.

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/84

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
