### PR TITLE
Fixed -- textarea태그 prefix공백 제거.

### DIFF
--- a/kara/accounts/templates/accounts/widgets/floating_label_textarea.html
+++ b/kara/accounts/templates/accounts/widgets/floating_label_textarea.html
@@ -8,8 +8,7 @@
         focus:outline-none focus:ring-0 focus:border-kara-strong peer
         "
         placeholder=" "
-    >
-    {% if widget.value %}{{ widget.value }}{% endif %}</textarea>
+    >{% if widget.value %}{{ widget.value }}{% endif %}</textarea>
     <label
         for="{{ widget.name }}"
         class="


### PR DESCRIPTION
## 작업 내용
textarea태그 Prefix공백을 제거했습니다.
### Before
<img width="511" alt="Screenshot 2025-05-03 at 4 02 09 PM" src="https://github.com/user-attachments/assets/186d3d34-b1ab-4e66-a4df-04148331c408" />

### After
<img width="493" alt="Screenshot 2025-05-03 at 4 03 33 PM" src="https://github.com/user-attachments/assets/9930004a-adf2-487e-a8a4-6937c418d832" />

## 연관된 이슈
- https://github.com/Antoliny0919/kara/issues/85

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
