### PR TITLE
Updated -- 프로필 페이지 컨텐츠 영역 반응형 레이아웃 적용.

### DIFF
--- a/kara/accounts/templates/accounts/profile.html
+++ b/kara/accounts/templates/accounts/profile.html
@@ -54,7 +54,7 @@
                     </li>
                 </ul>
             </aside>
-            <div class="w-[70%] flex flex-col items-center justify-center">
+            <div class="w-full flex flex-col items-center justify-center md:w-[70%]">
                 <div class="w-full px-8" x-show="activeTab === 'profile'">
                     <form method="post">
                         {% csrf_token %}
@@ -68,7 +68,7 @@
                                     {{ field.as_field_group }}
                                     {% if field.value == False %}
                                     <a class="
-                                    block mt-4 py-4 w-2/6 text-center text-kara-deep border-2 border-kara-strong rounded-lg duration-500 transition-color ml-auto
+                                    block text-sm mt-4 py-4 w-2/6 text-center text-kara-deep border-2 border-kara-strong rounded-lg duration-500 transition-color ml-auto
                                     hover:text-white hover:bg-kara-deep
                                     "
                                     role="button" href="{% url 'email_confirmation_resend' %}">{% trans 'Confirm Now!' %}</a>


### PR DESCRIPTION
## 작업 내용
프로필 페이지가 768px이하일때 width를 70%만 사용하는 현상을 수정했습니다.
반응형 레이아웃을 적용하여 768px 이하일때는 width를 100%사용하도록 했습니다.

추가로 이메일 인증버튼 폰트 크기를 `sm`사이즈로 줄였습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- https://github.com/Antoliny0919/kara/issues/101

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
