### PR TITLE
Updated -- 축의금 기록 저장소 디테일 페이지 헤더 추가.

### DIFF
--- a/kara/cash_gifts/locale/ko/LC_MESSAGES/django.po
+++ b/kara/cash_gifts/locale/ko/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-13 11:21+0900\n"
+"POT-Creation-Date: 2025-05-13 18:34+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgstr "축의금 기록을 작성하는 분의 이름을 입력해주세요."
 msgid "Please check to include in kind gifts details."
 msgstr "현물 선물 기록을 포함하려면 체크해주세요."
 
-#: kara/cash_gifts/forms.py:34
+#: kara/cash_gifts/forms.py:33
 msgid "Select Groom's or Bride's Side"
 msgstr "신랑 / 신부 측 선택"
 
@@ -48,10 +48,12 @@ msgid "Receiver"
 msgstr "수령인"
 
 #: kara/cash_gifts/models.py:28
+#: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html:21
 msgid "Receptionist"
 msgstr "기록인"
 
 #: kara/cash_gifts/models.py:30
+#: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html:16
 msgid "Wedding Date"
 msgstr "결혼식 날짜"
 
@@ -84,6 +86,17 @@ msgstr "축의금 기록 저장소를 추가해 보세요!"
 #: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_add.html:18
 msgid "Add"
 msgstr "추가하기"
+
+#: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html:5
+#: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html:7
+#, python-format
+msgid "%(receiver)s's Cash Gifts Records | Kara"
+msgstr "%(receiver)s님의 축의금 기록 | Kara"
+
+#: kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html:13
+#, python-format
+msgid "Congratulations on your wedding, %(receiver)s!"
+msgstr "결혼을 축하드립니다, %(receiver)s님!"
 
 #: kara/cash_gifts/views.py:30
 msgid ""

--- a/kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html
+++ b/kara/cash_gifts/templates/cash_gifts/gifts_record_repository_detail.html
@@ -1,2 +1,29 @@
-<h1>Gifts Record Repository Detail!!</h1>
-<h1>{{ object.honoree }}</h1>
+{% extends "base/base.html" %}
+
+{% load i18n %}
+
+{% block title %}{% blocktranslate with receiver=object.receiver %}{{ receiver }}'s Cash Gifts Records | Kara{% endblocktranslate %}{% endblock %}
+
+{% block meta_title %}{% blocktranslate with receiver=object.receiver %}{{ receiver }}'s Cash Gifts Records | Kara{% endblocktranslate %}{% endblock %}
+
+{% block content %}
+<main>
+    <div class="my-16">
+        <header>
+            <h1 class="text-4xl text-center my-4">{% blocktranslate with receiver=object.receiver %}Congratulations on your wedding, {{ receiver}}!{% endblocktranslate %}</h1>
+            <div class="ml-auto w-fit my-4">
+                <div class="grid grid-cols-[80px_20px_1fr] gap-1">
+                    <div class="text-right text-kara-strong">{% trans 'Wedding Date' %}</div>
+                    <div class="text-center text-kara-base">:</div>
+                    <div class="">{{ object.wedding_date }}</div>
+                </div>
+                <div class="grid grid-cols-[80px_20px_1fr] gap-1">
+                    <div class="text-right text-kara-strong">{% trans 'Receptionist' %}</div>
+                    <div class="text-center text-kara-base">:</div>
+                    <div>{{ object.receptionist }}</div>
+                </div>
+            </div>
+        </header>
+    </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
## 작업 내용
축의금 기록 저장소 디테일 페이지 헤더를 추가했습니다.

<img width="860" alt="Screenshot 2025-05-13 at 6 37 07 PM" src="https://github.com/user-attachments/assets/0049caac-4632-4870-9eaa-2e0e4968f455" />

현재는 아직 대략적인 디자인이며 레이아웃의 위치는 위와같이 진행될거 같습니다.
폰트, header 타이틀(Congratulations on your ...) 디자인 등등 추가적인 작업이 필요합니다.

## 연관된 작업

- ❌

## 연관된 이슈

- https://github.com/Antoliny0919/kara/issues/114

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
