### PR TITLE
Refactor -- 일부 위젯 tailwind css를 일반 css로 전환.

### DIFF
--- a/kara/base/templates/base/widgets/input.html
+++ b/kara/base/templates/base/widgets/input.html
@@ -1,24 +1,4 @@
 <div class="relative">
-    <input
-        type="{{ widget.type }}"
-        name="{{ widget.name }}"
-        class="
-        block w-full px-2.5 pb-2.5 pt-4 text-lg text-gray-900 bg-transparent rounded-lg border-2 border-kara-base appearance-none
-        focus:outline-none focus:ring-0 focus:border-kara-strong peer
-        "
-        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
-        {% include "django/forms/widgets/attrs.html" %}
-        placeholder=" "
-    >
-    <label
-        for="{{ widget.name }}"
-        class="
-        absolute text-lg text-kara-light duration-300 transform -translate-y-4 scale-75 top-2 z-10 origin-[0] bg-white px-2 start-1
-        peer-focus:px-2 peer-focus:text-kara-strong peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-6 peer-focus:left-4
-        peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2
-        peer-[&:not(:placeholder-shown)]:text-kara-strong peer-[&:not(:placeholder-shown)]:-translate-y-6 peer-[&:not(:placeholder-shown)]:left-4
-        "
-    >
-    {{ widget.attrs.label }}
-    </label>
+    <input type="{{ widget.type }}" name="{{ widget.name }}" {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %} {% include "django/forms/widgets/attrs.html" %} placeholder=" ">
+    <label for="{{ widget.name }}">{{ widget.attrs.label }}</label>
 </div>

--- a/kara/base/templates/base/widgets/radio.html
+++ b/kara/base/templates/base/widgets/radio.html
@@ -6,14 +6,8 @@
     <div>
     {% with widget=option %}
     <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-    <input type="{{ widget.type }}"
-    class="
-    w-5 h-5 rounded-full appearance-none border-2 border-kara-light transition-color duration-500 mr-2 text-kara-strong
-    checked:border-[0.4em] checked:border-kara-strong hover:shadow-[0_0_0_0.2em_var(--kara-light)] cursor-pointer peer
-    focus:outline-none focus:ring-0 focus:border-0
-    "
-    name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
-    {{ widget.label }}
+      <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+      {{ widget.label }}
     </label>
     {% endwith %}{% endfor %}
     </div>{% endfor %}

--- a/kara/static/css/kara.css
+++ b/kara/static/css/kara.css
@@ -1,7 +1,20 @@
 :root {
     --kara-light: #F3AFC2;
+    --kara-light-shallow: rgba(243, 175, 194, 0.2);
     --kara-base: #E46A88;
+    --kara-base-shallow: rgba(228, 106, 136, 0.2);
     --kara-strong: #C44B6B;
+    --kara-strong-shallow: rgba(196, 75, 107, 0.2);
+}
+
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number] {
+    -moz-appearance: textfield;
 }
 
 .brand-icon {
@@ -48,4 +61,121 @@
 
 .burger-menu.active span:nth-child(3) {
     transform: rotate(-45deg);
+}
+
+/* INPUT */
+
+input:is(
+    :not([type]),
+    [type="text"],
+    [type="password"],
+    [type="email"],
+    [type="number"]
+) {
+    display: block;
+    width: 100%;
+    padding: 0.825rem;
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    color: #111827;
+    background-color: transparent;
+    border-radius: 0.5rem;
+    border-width: 2px;
+    border-color: var(--kara-base);
+    appearance: none;
+}
+
+input:is(
+    :not([type]),
+    [type="text"],
+    [type="password"],
+    [type="email"],
+    [type="number"]
+):focus {
+    outline: none;
+    box-shadow: none;
+    border-color: var(--kara-strong);
+}
+
+input:is(
+    :not([type]),
+    [type="text"],
+    [type="password"],
+    [type="email"],
+    [type="number"]
+) + label {
+    position: absolute;
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    color: var(--kara-light);
+    transition-duration: 300ms;
+    transform: translateY(-1rem) scale(0.75);
+    top: 0.5rem;
+    z-index: 10;
+    transform-origin: 0;
+    background-color: white;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    left: 0.25rem;
+}
+
+input:is(
+    :not([type]),
+    [type="text"],
+    [type="password"],
+    [type="email"],
+    [type="number"]
+):placeholder-shown + label {
+    transform: translateY(-50%) scale(1);
+    top: 50%;
+}
+
+input:is(
+  :not([type]),
+  [type="text"],
+  [type="password"],
+  [type="email"],
+  [type="number"]
+):is(:focus:placeholder-shown, :focus, :not(:placeholder-shown)) + label {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  color: var(--kara-strong);
+  top: 0.5rem;
+  transform: translateY(-1.25rem) scale(0.75);
+  left: 1rem;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type="number"] {
+    -moz-appearance: textfield;
+}
+
+input[type="radio"] {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: calc(infinity * 1px);
+    appearance: none;
+    border: 2px solid var(--kara-light);
+    transition-property: color, background-color, border-color, border, text-decoration-color, fill, stroke;
+    transition-duration: 500ms;
+    margin-right: 0.5rem;
+    color: var(--kara-strong);
+    cursor: pointer;
+}
+
+input[type="radio"]:checked {
+    border: 0.4em solid var(--kara-strong);
+}
+
+input[type="radio"]:hover {
+    box-shadow: 0 0 0 0.2em var(--kara-light);
+}
+
+input[type="radio"]:focus {
+    --tw-ring-shadow: 0 0 #000 !important;
 }


### PR DESCRIPTION
## 작업 내용
`input`, `radio`위젯의 tailwind css를 일반 css로 전환했습니다.
tailwind를 사용하면 class속성값이 길어지기 때문에 템플릿을 테스트할때 어려움이 존재했습니다.
이 문제를 해결하기 위해 일부 tailwind css를 일반 css로 전환했으며 이후에 추가로 계속해서 전환할 예정입니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
