### PR TITLE
Fixed -- date input 위젯 decompress 일,월,연 순서를 연,월,일 으로 변경.

### DIFF
--- a/kara/base/templates/base/base.html
+++ b/kara/base/templates/base/base.html
@@ -10,6 +10,7 @@
         {% tailwind_css %}
         <link rel="stylesheet" href="{% static 'css/dist/fonts.css' %}">
         <link rel="stylesheet" href="{% static 'css/kara.css' %}">
+        <link rel="stylesheet" href="{% static 'css/widgets.css' %}">
 	</head>
     <body class="flex flex-col h-screen font-common {% block body_class %}{% endblock %}">
         {% block navbar %}{% include 'base/includes/nav.html' %}{% endblock %}

--- a/kara/base/templates/base/widgets/date.html
+++ b/kara/base/templates/base/widgets/date.html
@@ -1,9 +1,9 @@
-<fieldset class="relative rounded-lg border-2 border-kara-strong px-4 pb-4">
+<fieldset class="date-input-container relative rounded-lg border-2 border-kara-strong px-4 pb-4">
     <legend class="bg-white text-kara-strong p-2 text-sm">{{ widget.attrs.label }}</legend>
     <div class="flex flex-row items-center justify-center">
     {% for widget in widget.subwidgets %}
         <div>
-            <input name={{ widget.name }} type="text" class="w-full p-0 outline-none border-none text-center focus:outline-none focus:ring-0 focus:border-none" {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}></input>
+            <input name={{ widget.name }} type="text" {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}></input>
         </div>
         {% if not forloop.last %}<span class="text-lg text-gray-400">/</span>{% endif %}
     {% endfor %}

--- a/kara/base/tests/test_widgets.py
+++ b/kara/base/tests/test_widgets.py
@@ -21,9 +21,25 @@ class KaraSplitDateInputWidgetTests(SimpleTestCase):
         for value, year, month, day in case:
             with self.subTest(initial_value=value):
                 form = EventForm(initial={"event_date": value})
-                self.assertIn(f'value="{year}"', form.as_div())
-                self.assertIn(f'value="{month}"', form.as_div())
-                self.assertIn(f'value="{day}"', form.as_div())
+                render_form = form.as_div()
+                self.assertIn(
+                    f'<input name=event_date_0 type="text" value="{year}" '
+                    'placeholder="YYYY" maxlength="4" required id="id_event_date_0">'
+                    "</input>",
+                    render_form,
+                )
+                self.assertIn(
+                    f'<input name=event_date_1 type="text" value="{month}" '
+                    'placeholder="MM" maxlength="2" required id="id_event_date_1">'
+                    "</input>",
+                    render_form,
+                )
+                self.assertIn(
+                    f'<input name=event_date_2 type="text" value="{day}" '
+                    'placeholder="DD" maxlength="2" required id="id_event_date_2">'
+                    "</input>",
+                    render_form,
+                )
 
     def test_value_from_datadict(self):
         data = {

--- a/kara/base/widgets.py
+++ b/kara/base/widgets.py
@@ -50,7 +50,7 @@ class KaraSplitDateInput(MultiWidget):
 
     def decompress(self, value):
         if isinstance(value, date):
-            return [value.day, value.month, value.year]
+            return [value.year, value.month, value.day]
         elif isinstance(value, str):
             year, month, day = value.split("-")
             return [year, month, day]

--- a/kara/static/css/widgets.css
+++ b/kara/static/css/widgets.css
@@ -1,0 +1,5 @@
+/* DATE INPUT */
+
+.date-input-container input {
+    padding: 0;
+}


### PR DESCRIPTION
## 작업 내용
date input 위젯 decompress메서드에서 `datetime.date`객체가 전달되었을때 해당 값이 decompress될때 일, 월, 연으로 되어있었습니다.
그렇기 때문에 기존 위젯에서 초기값이 연도입력에 일이입력되어있고 일입력에 연이 입력되어있었습니다.
decompress로직을 수정하여 연, 월, 일으로 전달되도록 수정했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
