### PR TITLE
Refactor -- radio위젯 템플릿 input, container 분리.

### DIFF
--- a/kara/base/templates/base/widgets/radio.html
+++ b/kara/base/templates/base/widgets/radio.html
@@ -1,15 +1,4 @@
-<fieldset class="relative rounded-lg border-2 border-kara-strong px-4 pb-4" {% if field.aria_describedby %} aria-describedby="{{ field.aria_describedby }}"{% endif %}>
-  <legend class="bg-white text-kara-strong p-2 text-sm">{{ widget.attrs.label }}</legend>
-  {% with id=widget.attrs.id %}
-  <div{% if id %} id="{{ id }}"{% endif %} class="flex justify-around">{% for group, options, index in widget.optgroups %}
-    {% for option in options %}
-    <div>
-    {% with widget=option %}
-    <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
-      <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
-      {{ widget.label }}
-    </label>
-    {% endwith %}{% endfor %}
-    </div>{% endfor %}
-  </div>{% endwith %}
-</fieldset>
+<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+  <input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+  {{ widget.label }}
+</label>

--- a/kara/base/templates/base/widgets/radio_select.html
+++ b/kara/base/templates/base/widgets/radio_select.html
@@ -1,0 +1,11 @@
+<fieldset class="relative rounded-lg border-2 border-kara-strong px-4 pb-4" {% if field.aria_describedby %} aria-describedby="{{ field.aria_describedby }}"{% endif %}>
+  <legend class="bg-white text-kara-strong p-2 text-sm">{{ widget.attrs.label }}</legend>
+  {% with id=widget.attrs.id %}
+  <div{% if id %} id="{{ id }}"{% endif %} class="flex justify-around">{% for group, options, index in widget.optgroups %}
+    {% for option in options %}
+    <div>
+    {% include 'base/widgets/radio.html' with widget=option %}
+    {% endfor %}
+    </div>{% endfor %}
+  </div>{% endwith %}
+</fieldset>

--- a/kara/base/widgets.py
+++ b/kara/base/widgets.py
@@ -14,7 +14,7 @@ from django.forms.widgets import (
 
 
 class KaraRadioSelect(RadioSelect):
-    template_name = "base/widgets/radio.html"
+    template_name = "base/widgets/radio_select.html"
 
 
 class KaraEmailInput(EmailInput):


### PR DESCRIPTION
## 작업 내용
기존 radio위젯 템플릿인 `radio.html`에는 컨테이너와 radio가 같이 존재했지만 radio부분만 따로 분리하여 컨테이너 템플릿은 `radio_select.html`에 위치하고 radio input은 `radio.html`에 위치하도록 분리했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
