### PR TITLE
Fixed -- 부분 템플릿 렌더 믹스인 htmx 이외 요청 허용.

### DIFF
--- a/kara/base/views.py
+++ b/kara/base/views.py
@@ -8,17 +8,20 @@ class PartialTemplateResponseMixin(TemplateResponseMixin):
     partial_template_identifier = None
 
     def get_template_names(self):
-        if self.template_name is None or self.partial_template_identifier is None:
-            raise ImproperlyConfigured(
-                "PartialTemplateResponseMixin requires either a definition of "
-                "'template_name' and 'partial_template_id' or "
-                "an implementation of 'get_template_names()'"
-            )
+        if self.request.htmx:
+            if self.template_name is None or self.partial_template_identifier is None:
+                raise ImproperlyConfigured(
+                    "PartialTemplateResponseMixin requires either a definition of "
+                    "'template_name' and 'partial_template_identifier' or "
+                    "an implementation of 'get_template_names()'"
+                )
+            else:
+                partial_template_name = (
+                    self.template_name + self.partial_template_identifier
+                )
+                return [partial_template_name]
         else:
-            partial_template_name = (
-                self.template_name + self.partial_template_identifier
-            )
-            return [partial_template_name]
+            return super().get_template_names()
 
 
 class PartialTemplateFormMixin(FormMixin):


### PR DESCRIPTION
## 작업 내용
`PartialTemplateResponseMixin`클래스에 `request.htmx`조건을 추가하여 htmx요청이 아닌 일반 요청일때 부분템플릿이 아닌 전체템플릿이 렌더링 가능하도록 수정했습니다.
하나의 View로직에서 htmx 여부에 따라 부분 템플릿, 전체 템플릿을 반환해야 하는 상황을 커버합니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
