### PR TITLE
Updated -- 결혼 선물 저장소 디테일 페이지 폼, 테이블 레이아웃 수정.

### DIFF
--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -27,19 +27,22 @@
             </div>
         </header>
         {% partialdef gift-records-section inline %}
-        <div id="gift-records-section" class="flex justify-between">
-            <div class="flex-1 mx-8">
-                <h2 class="text-2xl text-center my-4">{% translate 'Add Cash Gift Record' %}</h2>
-                <div class="px-12 pt-10 border-2 border-kara-strong rounded-xl">
-                    <form method="post" hx-post="{% url 'add_cash_gift' object.pk %}" hx-target="#gift-records-section" hx-swap="outerHTML">
-                        {% csrf_token %}
-                        {{ cash_gift_form }}
-                        <button type="submit" class="block py-4 my-6 bg-kara-base w-1/3 border-2 border-kara-base rounded-lg text-white transition-color duration-500 mx-auto hover:bg-white hover:text-kara-strong">{% trans 'Add' %}</button>
-                    </form>
+        <div id="gift-records-section">
+            <div class="flex">
+                <div class="flex-1 mx-8">
+                    <h2 class="text-2xl text-center my-4">{% translate 'Add Cash Gift Record' %}</h2>
+                    <div class="px-12 pt-10 border-2 border-kara-strong rounded-xl">
+                        <form method="post" hx-post="{% url 'add_cash_gift' object.pk %}" hx-target="#gift-records-section" hx-swap="outerHTML">
+                            {% csrf_token %}
+                            {{ cash_gift_form }}
+                            <button type="submit" class="block py-4 my-6 bg-kara-base w-1/3 border-2 border-kara-base rounded-lg text-white transition-color duration-500 mx-auto hover:bg-white hover:text-kara-strong">{% trans 'Add' %}</button>
+                        </form>
+                    </div>
                 </div>
+                <div class="flex-1"></div>
             </div>
-            <div class="flex-1 mx-8">
-                <h2 class="text-2xl text-center my-4">{% blocktranslate with receiver=object.receiver %}{{ receiver }}'s Gift Records{% endblocktranslate %}</h2>
+            <div class="mx-8 my-20">
+                <h2 class="text-2xl text-center my-4">{% blocktranslate with receiver=object.receiver %}{{ receiver }}'s Cash Gift Records{% endblocktranslate %}</h2>
                 {% partialdef gifts-table inline %}
                 <div id="gifts-table">
                     <div class="table-area border-2 border-kara-strong rounded-xl">


### PR DESCRIPTION
## 작업 내용
결혼 선물 저장소 디테일 페이지에서 폼과 테이블은 같은 라인에 위치했습니다.
이후에 테이블에서 필드가 더 추가될 예정이기때문에 이전 구조에서는 테이블의 공간이 너무나도 부족했습니다.
폼과 테이블을 Column으로 분리하여 테이블영역이 더 공간을 가질 수 있도록 수정했습니다.
<img width="1254" alt="Screenshot 2025-05-25 at 9 54 27 AM" src="https://github.com/user-attachments/assets/e8eb3c70-9d8b-428c-89c5-6f625cd3a332" />

현재 Form은 `flex-1`을 통해 절반의 레이아웃만 사용하지만 차후에 폼 오른쪽부분에 태그를 추가하는 폼이 추가될 예정입니다.
Table또한 현재는 세개의 필드만 나타내서 공간이 많아보이지만 차후에 공통적으로 action선택 버튼이나 Tag필드가 추가될 예정입니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
