### PR TITLE
Refactor -- 결혼 선물 저장소 디테일 페이지 테이블 영역 태그 section으로 변경.

### DIFF
--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -43,8 +43,8 @@
             </div>
             <div class="mx-8 my-20">
                 <h2 class="text-2xl text-center my-4">{% blocktranslate with receiver=object.receiver %}{{ receiver }}'s Cash Gift Records{% endblocktranslate %}</h2>
-                {% partialdef gifts-table inline %}
-                <div id="gifts-table">
+                {% partialdef gift-records-table-section inline %}
+                <section id="gift-records-table-section">
                     <div class="table-area border-2 border-kara-strong rounded-xl">
                         <table class="w-full text-left">
                             <thead class="uppercase">
@@ -67,8 +67,8 @@
                             </tbody>
                         </table>
                     </div>
-                    {% pagination table.pagination htmx_target="#gifts-table" %}
-                </div>
+                    {% pagination table.pagination htmx_target="#gift-records-table-section" %}
+                </section>
                 {% endpartialdef %}
             </div>
         </div>

--- a/kara/wedding_gifts/tests/test_wedding_gift_registry_detail_view.py
+++ b/kara/wedding_gifts/tests/test_wedding_gift_registry_detail_view.py
@@ -56,17 +56,17 @@ class TestPlaywright:
         self.registry_pk = registry.pk
 
     def test_pagination(self, auth_page, live_server, setup_data):
-        url = reverse("registry", args=(self.registry_pk,))
+        url = reverse("detail_registry", args=(self.registry_pk,))
         auth_page.goto(live_server.url + f"{url}?page=5")
         current_page_button = auth_page.locator("nav.pagination em.current-page")
         expect(current_page_button).to_have_text("5")
-        rows = auth_page.locator("div#gifts-table table tbody tr")
+        rows = auth_page.locator("section#gift-records-table-section table tbody tr")
         # Verify the table contents displayed on page 5
         expect(rows.first.locator("td").first).to_have_text("cash-gift-160")
         expect(rows.last.locator("td").first).to_have_text("cash-gift-151")
         auth_page.locator('nav.pagination a[href*="?page=8"]').click()
         expect(auth_page).to_have_url(re.compile(r"page=8"))
-        rows = auth_page.locator("div#gifts-table table tbody tr")
+        rows = auth_page.locator("section#gift-records-table-section table tbody tr")
         # Verify the table contents displayed on page 8
         expect(rows.first.locator("td").first).to_have_text("cash-gift-130")
         expect(rows.last.locator("td").first).to_have_text("cash-gift-121")

--- a/kara/wedding_gifts/views.py
+++ b/kara/wedding_gifts/views.py
@@ -49,7 +49,7 @@ class WeddingGiftRegistryDetailView(LoginRequiredMixin, PartialTemplateDetailVie
     def get_template_names(self):
         if self.request.htmx and self.request.GET:
             # Only render the table for HTMX GET requests
-            self.partial_template_identifier = "#gifts-table"
+            self.partial_template_identifier = "#gift-records-table-section"
         return super().get_template_names()
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## 작업 내용
결혼 선물 저장소 디테일 페이지 테이블 영역 태그를 `<div>` -> `<section>`으로 변경했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
