### PR TITLE
Updated -- Table 헤더 정렬 htmx 적용.

### DIFF
--- a/kara/base/templates/base/tables/table.html
+++ b/kara/base/templates/base/tables/table.html
@@ -2,23 +2,17 @@
 
 <div class="table-container">
     <table id="table" class="w-full text-left">
-        <thead class="uppercase">
+        <thead class="uppercase" {% if htmx_target %}hx-target="{{ htmx_target }}" hx-swap="outerHTML" hx-push-url="true"{% endif %}>
             <tr>
                 {% for header in table_headers %}
                 <th scope="col" {{ header.class_attr }}>
-                    <div class="text">{% if header.sort %}<a href="{% querystring table.params header.sort %}">{{ header.text }}</a>{% else %}{{ header.text }}{% endif %}</div>
+                    <div class="text">{% if header.sort %}<a {% if htmx_target %}hx-get{% else %}href{% endif %}="{% querystring table.params header.sort %}">{{ header.text }}</a>{% else %}{{ header.text }}{% endif %}</div>
                     {% if header.sortable and header.sorted %}
                     <div class="sortoptions">
                         {% blocktranslate asvar remove_sort_help_text with target=header.text %}Remove from sorting {{ target }}{% endblocktranslate %}
                         {% blocktranslate asvar sort_help_text with target=header.text direction=header.order_type %}Toggle sorting {{ target }} {{ direction }}{% endblocktranslate %}
-                        <a href="{% querystring table.params header.remove_sort %}" class="sortremove"
-                        title="{{ remove_sort_help_text }}"
-                        aria-label="{{ remove_sort_help_text }}"
-                        ></a>
-                        <a href="{% querystring table.params header.reverse_sort %}" class="toggle {{ header.order_type }}"
-                        title="{{ sort_help_text }}"
-                        aria-label="{{ sort_help_text }}"
-                        ></a>
+                        <a {% if htmx_target %}hx-get{% else %}href{% endif %}="{% querystring table.params header.remove_sort %}" class="sortremove" title="{{ remove_sort_help_text }}" aria-label="{{ remove_sort_help_text }}"></a>
+                        <a {% if htmx_target %}hx-get{% else %}href{% endif %}="{% querystring table.params header.reverse_sort %}" class="toggle {{ header.order_type }}" title="{{ sort_help_text }}" aria-label="{{ sort_help_text }}"></a>
                     </div>
                     {% endif %}
                 </th>

--- a/kara/base/templatetags/tables.py
+++ b/kara/base/templatetags/tables.py
@@ -134,8 +134,9 @@ def table_headers(table):
 
 
 @register.inclusion_tag("base/tables/table.html", name="table")
-def render_table(table):
+def render_table(table, **kwargs):
     return {
         "table_headers": table_headers(table),
         "table": table,
+        **kwargs,
     }

--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -60,7 +60,7 @@
                         {% if table.search_fields %}
                         {% search_form table htmx_target="#gift-records-table-section" %}
                         {% endif %}
-                        {% table table %}
+                        {% table table htmx_target="#gift-records-table-section" %}
                         {% pagination table.pagination htmx_target="#gift-records-table-section" %}
                     </section>
                     {% endpartialdef %}


### PR DESCRIPTION
## 작업 내용
Table 헤더에 htmx를 적용하여 화면 전체 리렌더링 하지 않고 특정한 부분만 렌더링합니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
