### PR TITLE
Refactor -- HTMX를 사용하는 태그에 선택적 HTMX적용.

### DIFF
--- a/kara/base/templates/base/tables/pagination.html
+++ b/kara/base/templates/base/tables/pagination.html
@@ -2,18 +2,18 @@
 
 {% if pagination.multi_page %}
 <div class="paginate-container">
-    <nav class="pagination" aria-labelledby="pagination" hx-target="{{ htmx_target|default:"#table" }}" hx-swap=outerHTML hx-push-url=true>
+    <nav class="pagination" aria-labelledby="pagination" {% if htmx_target %}hx-target="{{ htmx_target }}" hx-swap="outerHTML" hx-push-url="true"{% endif %}>
         <h2 id="pagination" class="sr-only">{% blocktranslate with name=pagination.opts.verbose_name_plural %}Pagination {{ name }}{% endblocktranslate %}</h2>
         {% if pagination.page.has_previous %}
-            <a class="previous-page" href="{% querystring pagination.params previous_page %}" hx-get="{% querystring pagination.params previous_page %}" rel="prev" aria-label="Previous page">{% trans 'Previous '%}</a>
+            <a class="previous-page" {% if htmx_target %}hx-get{% else %}href{% endif %}="{% querystring pagination.params previous_page %}" rel="prev" aria-label="Previous page">{% trans 'Previous '%}</a>
         {% else %}
             <span class="previous-page disabled" rel="prev" aria-label="Previous page">{% trans 'Previous '%}</span>
         {% endif %}
         {% for i in pagination.page_range %}
-            {% pagination_number pagination i %}
+            {% pagination_number pagination i htmx_target %}
         {% endfor %}
         {% if pagination.page.has_next %}
-            <a class="next-page" href="{% querystring pagination.params next_page %}" hx-get="{% querystring pagination.params next_page %}" rel="next" aria-label="Next page">{% trans 'Next' %}</a>
+            <a class="next-page" {% if htmx_target %}hx-get{% else %}href{% endif %}="{% querystring pagination.params next_page %}" rel="next" aria-label="Next page">{% trans 'Next' %}</a>
         {% else %}
             <span class="next-page disabled" rel="next" aria-label="Next page">{% trans 'Next' %}</span>
         {% endif %}

--- a/kara/base/templates/base/tables/search_form.html
+++ b/kara/base/templates/base/tables/search_form.html
@@ -2,7 +2,7 @@
 
 <div class="my-6 w-1/2 min-w-[480px]">
     <h2 id="table-search-form" class="sr-only">{% blocktranslate %}Search {{ model_name }}{% endblocktranslate %}</h2>
-    <form method="get" role="search" hx-target="{{ htmx_target|default:"#table" }}" hx-get="{% querystring table.params clear_param %}" hx-push-url="true" aria-labelledby="table-search-form">
+    <form method="get" role="search" {% if htmx_target %}hx-get="{% querystring table.params clear_param %}" hx-target="{{ htmx_target }}" hx-push-url="true"{% else %}href="{% querystring table.params clear_param %}"{% endif %} aria-labelledby="table-search-form">
         <div class="flex flex-col">
             <div class="w-[32rem] flex flex-row space-x-4">
                 {{ field }}

--- a/kara/base/templatetags/tables.py
+++ b/kara/base/templatetags/tables.py
@@ -9,7 +9,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def pagination_number(pagination, i):
+def pagination_number(pagination, i, htmx):
     """
     Generate an individual page index link in a paginated list.
     """
@@ -19,9 +19,10 @@ def pagination_number(pagination, i):
         return format_html('<em class="current-page" aria-current="page">{}</em> ', i)
     else:
         link = querystring(None, pagination.params, {settings.PAGE_VAR: i})
+        link_key = "href" if htmx is None else "hx-get"
         return format_html(
-            '<a href="{}" hx-get="{}" aria-label="page {}" {}>{}</a> ',
-            link,
+            '<a {}="{}" aria-label="page {}" {}>{}</a> ',
+            link_key,
             link,
             i,
             mark_safe(' class="end"' if i == pagination.paginator.num_pages else ""),


### PR DESCRIPTION
## 작업 내용
HTMX를 사용하는 태그.
- pagination
- search
- table

선택적으로 HTMX가 사용되도록 수정했습니다.
템플릿 태그에 전달되는 `htmx_target`에 의해 결정됩니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
