### PR TITLE
Fixed -- 테이블 Column Order 정렬제거시 partial-template이 잘못지정되는 버그 수정.

### DIFF
--- a/kara/base/views.py
+++ b/kara/base/views.py
@@ -8,20 +8,17 @@ from .utils import pascal_to_snake
 
 
 class PartialTemplateResponseMixin(TemplateResponseMixin):
-    partial_template_identifier = None
 
     def get_template_names(self):
         if self.request.htmx:
-            if self.template_name is None or self.partial_template_identifier is None:
+            htmx_target = self.request.headers.get("Hx-Target", None)
+            if self.template_name is None or htmx_target is None:
                 raise ImproperlyConfigured(
-                    "PartialTemplateResponseMixin requires either a definition of "
-                    "'template_name' and 'partial_template_identifier' or "
-                    "an implementation of 'get_template_names()'"
+                    "PartialTemplateResponseMixin requires 'template_name' to be "
+                    "defined and the request must include an 'Hx-Target' header."
                 )
             else:
-                partial_template_name = (
-                    self.template_name + self.partial_template_identifier
-                )
+                partial_template_name = self.template_name + f"#{htmx_target}"
                 return [partial_template_name]
         else:
             return super().get_template_names()

--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -57,11 +57,11 @@
                 <div class="py-8 px-12 border-2 border-kara-strong">
                     {% partialdef gift-records-table-section inline %}
                     <section id="gift-records-table-section">
-                        {% if table.search_fields %}
-                        {% search_form table htmx_target="#gift-records-table-section" %}
+                        {% if gift_table.search_fields %}
+                        {% search_form gift_table htmx_target="#gift-records-table-section" %}
                         {% endif %}
-                        {% table table htmx_target="#gift-records-table-section" %}
-                        {% pagination table.pagination htmx_target="#gift-records-table-section" %}
+                        {% table gift_table htmx_target="#gift-records-table-section" %}
+                        {% pagination gift_table.pagination htmx_target="#gift-records-table-section" %}
                     </section>
                     {% endpartialdef %}
                 </div>

--- a/kara/wedding_gifts/tests/test_views.py
+++ b/kara/wedding_gifts/tests/test_views.py
@@ -40,12 +40,12 @@ class CashGiftAddViewTests(TestCase):
                 "receipt_date_2": "19",
             },
             HTTP_HX_REQUEST="true",
+            HTTP_HX_TARGET="gift-records-section",
             follow=True,
         )
         self.assertContains(response, "<td>Tim Bread</td>")
         self.assertContains(response, "<td>100,000</td>")
         self.assertContains(response, "<td>2020-05-19</td>")
-        self.assertIn("#gift-records-section", response.template_name[0])
 
     def test_reuse_before_selected_price_button(self):
         response = self.client.get(self.url)
@@ -88,22 +88,6 @@ class WeddingGiftRegistryDetailViewTests(TestCase):
 
     def setUp(self):
         self.client.force_login(self.user)
-
-    def test_template_response(self):
-        response = self.client.get(self.url)
-        self.assertNotIn("#gift-records-table-section", response.template_name[0])
-        # Use partial template when it's an HTMX request with query string
-        response = self.client.get(
-            self.query_url,
-            HTTP_HX_REQUEST="true",
-        )
-        self.assertIn("#gift-records-table-section", response.template_name[0])
-
-    def test_form_context(self):
-        response = self.client.get(self.url)
-        self.assertIn("gift_form", response.context)
-        response = self.client.get(self.query_url, HTTP_HX_REQUEST="true")
-        self.assertNotIn("gift_form", response.context)
 
     def test_context_from_mixin(self):
         response = self.client.get(self.url)
@@ -148,7 +132,7 @@ class TestPlaywright:
         # Verify the table contents displayed on page 5
         expect(rows.first.locator("td").first).to_have_text("cash-gift-160")
         expect(rows.last.locator("td").first).to_have_text("cash-gift-151")
-        auth_page.locator('nav.pagination a[href*="?page=8"]').click()
+        auth_page.locator('nav.pagination a[hx-get*="?page=8"]').click()
         expect(auth_page).to_have_url(re.compile(r"page=8"))
         rows = auth_page.locator("section#gift-records-table-section table tbody tr")
         # Verify the table contents displayed on page 8


### PR DESCRIPTION
## 작업 내용
테이블 Column Order시에 쿼리스트링 갯수에 의해 처리되는 로직이 존재했습니다.
```
        if request.method == "GET":
            if gift_type is None or (gift_type and len(dict(self.request.GET)) > 1):
                # If gift_type is missing from the query or
                # if multiple query parameters including gift_type are present,
                # only the table is partially updated.
                self.partial_template_identifier = "#gift-records-table-section"
```

위 로직에 의하여 `self.partial_template_identifier`가 gift-records-table-section이 되지 못했습니다.
위 로직을 제거하고 `PartialTemplateResponseMixin`에 `htmx-target`속성값을 partial_template으로 지정하도록 수정했습니다.


## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
