### PR TITLE
GiftTable 날짜 데이터 출력 포맷 지정.

### DIFF
--- a/kara/base/tests/models.py
+++ b/kara/base/tests/models.py
@@ -17,6 +17,7 @@ class Cake(models.Model):
     kind = models.CharField(choices=KIND_CHOICES)
     kind_detail = models.TextField()
     price = models.IntegerField()
+    expiration_date = models.DateField()
 
 
 class Character(models.Model):

--- a/kara/wedding_gifts/tables.py
+++ b/kara/wedding_gifts/tables.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
-from django.db.models import CharField, TextField
+from django.db.models import CharField, DateField, DateTimeField, TextField
 from django.template.defaultfilters import truncatewords
+from django.utils.formats import date_format
 from django.utils.translation import gettext_lazy as _
 
 from kara.base.tables import Table, TableSearchForm
@@ -28,6 +29,8 @@ class GiftTable(Table):
             value = getattr(obj, f"get_{column}_display")()
         elif isinstance(field, (CharField, TextField)):
             value = truncatewords(value, 8)
+        elif isinstance(field, (DateField, DateTimeField)):
+            value = date_format(value)
         elif column in self.int_commas and isinstance(value, (int, float)):
             value = intcomma(value)
         return value

--- a/kara/wedding_gifts/tests/test_tables.py
+++ b/kara/wedding_gifts/tests/test_tables.py
@@ -1,4 +1,6 @@
-from django.test import RequestFactory, TestCase
+from datetime import date
+
+from django.test import RequestFactory, TestCase, override_settings
 
 from kara.base.tests.models import Cake
 from kara.wedding_gifts.tables import GiftTable
@@ -8,6 +10,7 @@ class CakeTable(GiftTable):
     pass
 
 
+@override_settings(DATE_FORMAT="F j, Y")
 class GiftTableTest(TestCase):
 
     @classmethod
@@ -20,6 +23,7 @@ class GiftTableTest(TestCase):
                 "Cheese basque cake with italian cheese made by korea's best baker."
             ),
             price=100000000,
+            expiration_date=date(2029, 12, 31),
         )
         cls.factory = RequestFactory()
         cls.model = Cake
@@ -32,7 +36,9 @@ class GiftTableTest(TestCase):
         self.assertEqual(choice_value, "Cheese")
         price_value = table.display_for_value(self.cake, "price")
         self.assertEqual(price_value, "100,000,000")
-        long_char_value = table.display_for_value(self.cake, "kind_detail")
+        truncated_str_value = table.display_for_value(self.cake, "kind_detail")
         self.assertEqual(
-            long_char_value, "Cheese basque cake with italian cheese made by …"
+            truncated_str_value, "Cheese basque cake with italian cheese made by …"
         )
+        date_value = table.display_for_value(self.cake, "expiration_date")
+        self.assertEqual(str(date_value), "Dec. 31, 2029")


### PR DESCRIPTION
## 작업 내용
`GiftTable`에 날짜 데이터 출력시 지정된 포맷이 적용되도록 로직을 추가했습니다.

<img width="456" alt="Screenshot 2025-06-13 at 11 00 00 AM" src="https://github.com/user-attachments/assets/20ad4fd8-e216-472f-a6e7-88a96db1854a" />

## 연관된 작업

- ❌

## 연관된 이슈

- https://github.com/Antoliny0919/kara/issues/149

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
