### PR TITLE
Test실행시 playwright테스트 실행 제외.(특정 옵션을 통해 실행)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 # ==== pytest ====
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ds=config.settings.test --reuse-db --import-mode=importlib"
+addopts = "--ds=config.settings.test -m 'not playwright' --reuse-db --import-mode=importlib"
 python_files = [
   "tests.py",
   "test_*.py",
+]
+markers = [
+  "playwright: mark test that requires playwright",
 ]
 
 # ==== black ====


### PR DESCRIPTION
## 작업 내용
일반 Test실행시 playwright마커가 존재하는 테스트는 제외하도록 수정했습니다.
playwright마커가 존재하는 테스트는 `-m playwright`를 통해 단독으로 수행할 수 있습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- https://github.com/Antoliny0919/kara/issues/109

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
