### PR TITLE
Refactor -- Pagination 파라미어 Model제거.

### DIFF
--- a/kara/base/pagination.py
+++ b/kara/base/pagination.py
@@ -8,14 +8,14 @@ class Pagination:
     def __init__(
         self,
         request,
-        model,
-        list_per_page,
         queryset,
+        list_per_page,
     ):
-        self.list_per_page = list_per_page
         self.queryset = queryset
+        model = queryset.model
         self.model = model
         self.opts = model._meta
+        self.list_per_page = list_per_page
         try:
             # Get the current page from the query string.
             self.page_num = int(request.GET.get(settings.PAGE_VAR, 1))

--- a/kara/base/tables.py
+++ b/kara/base/tables.py
@@ -130,7 +130,9 @@ class Table:
 
     def get_pagination_result(self, request, queryset):
         pagination = self.pagination_class(
-            request, self.model, self.list_per_page, queryset
+            request,
+            queryset,
+            self.list_per_page,
         )
         self.pagination = pagination
         return pagination.get_objects()

--- a/kara/base/tests/test_pagination.py
+++ b/kara/base/tests/test_pagination.py
@@ -16,10 +16,10 @@ class PaginationTest(TestCase):
 
     def test_pagination(self):
         request = self.factory.get("/fake-url/")
-        pagination = Pagination(request, 5, self.queryset)
+        pagination = Pagination(request, self.queryset, 5)
         self.assertEqual(pagination.result_count, 100)
         self.assertTrue(pagination.multi_page)
-        pagination = Pagination(request, 200, self.queryset)
+        pagination = Pagination(request, self.queryset, 200)
         self.assertFalse(pagination.multi_page)
 
     def test_pagination_page_range(self):
@@ -35,7 +35,7 @@ class PaginationTest(TestCase):
         ]
         for list_per_page, current_page, expected_page_range in case:
             with self.subTest(list_per_page=list_per_page, current_page=current_page):
-                pagination = Pagination(request, list_per_page, self.queryset)
+                pagination = Pagination(request, self.queryset, list_per_page)
                 pagination.page_num = current_page
                 self.assertEqual(list(pagination.page_range), expected_page_range)
 
@@ -54,7 +54,7 @@ class PaginationTest(TestCase):
             UserFactory.create(username=i)
         queryset = User.objects.all().order_by("id")
         for list_per_page, current_page, expect_object_names in case:
-            pagination = Pagination(request, list_per_page, queryset)
+            pagination = Pagination(request, queryset, list_per_page)
             pagination.page_num = current_page
             objects = pagination.get_objects()
             object_names = list(objects.values_list("username", flat=True))


### PR DESCRIPTION
## 작업 내용
`Pagination`클래스 파라미터중 model파라미터를 제거했습니다.
Pagination에 전달된 queryset을 통해 model을 가져옵니다.
추가로 `Pagination`파라미터중 list_per_page, queryset의 순서를 교체했습니다. qeuryset이 더 먼저옵니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
