### PR TITLE
Refactor -- gift_tag전환 버튼 속성 정리.

### DIFF
--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -32,7 +32,7 @@
                 <div class="flex-1">
                     <h2 class="text-2xl text-center my-4">{% translate 'Add Cash Gift Record' %}</h2>
                     <nav class="tab-selector gift-form">
-                        <ul hx-target="#gift-records-section" hx-swap="outerHTML">
+                        <ul hx-target="#gift-records-section" hx-swap="outerHTML" hx-push-url="true">
                             <li><a class="{% if gift_type == 'cash' %}active{% endif %}" hx-get="{% querystring gift_type='cash' %}">{% trans 'Cash Gift' %}</a></li>
                             <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" hx-get="{% querystring gift_type='in_kind' %}">{% trans 'In Kind Gift' %}</a></li>
                         </ul>
@@ -49,7 +49,7 @@
             </div>
             <div class="my-20">
                 <nav class="tab-selector gift-table">
-                    <ul hx-target="#gift-records-section" hx-swap="outerHTML">
+                    <ul hx-target="#gift-records-section" hx-swap="outerHTML" hx-push-url="true">
                         <li><a class="{% if gift_type == 'cash' %}active{% endif %}" hx-get="{% querystring gift_type='cash' %}">{% trans 'Cash Gift' %}</a></li>
                         <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" hx-get="{% querystring gift_type='in_kind' %}">{% trans 'In Kind Gift' %}</a></li>
                     </ul>

--- a/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/wedding_gift_registry_detail.html
@@ -33,8 +33,8 @@
                     <h2 class="text-2xl text-center my-4">{% translate 'Add Cash Gift Record' %}</h2>
                     <nav class="tab-selector gift-form">
                         <ul hx-target="#gift-records-section" hx-swap="outerHTML">
-                            <li><a class="{% if gift_type == 'cash' %}active{% endif %}" href="{{ detail_registry_url }}" hx-get="{{ detail_registry_url }}" hx-push-url="true" hx-vals='{"gift_type": "cash"}'>{% trans 'Cash Gift' %}</a></li>
-                            <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" href="{{ detail_registry_url }}" hx-get="{{ detail_registry_url }}" hx-push-url="true" hx-vals='{"gift_type": "in_kind"}'>{% trans 'In Kind Gift' %}</a></li>
+                            <li><a class="{% if gift_type == 'cash' %}active{% endif %}" hx-get="{% querystring gift_type='cash' %}">{% trans 'Cash Gift' %}</a></li>
+                            <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" hx-get="{% querystring gift_type='in_kind' %}">{% trans 'In Kind Gift' %}</a></li>
                         </ul>
                     </nav>
                     <div class="px-12 pt-10 border-2 border-kara-strong rounded-b-xl">
@@ -50,8 +50,8 @@
             <div class="my-20">
                 <nav class="tab-selector gift-table">
                     <ul hx-target="#gift-records-section" hx-swap="outerHTML">
-                        <li><a class="{% if gift_type == 'cash' %}active{% endif %}" href="{{ detail_registry_url }}" hx-get="{{ detail_registry_url }}" hx-push-url="true" hx-vals='{"gift_type": "cash"}'>{% trans 'Cash Gift' %}</a></li>
-                        <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" href="{{ detail_registry_url }}" hx-get="{{ detail_registry_url }}" hx-push-url="true" hx-vals='{"gift_type": "in_kind"}'>{% trans 'In Kind Gift' %}</a></li>
+                        <li><a class="{% if gift_type == 'cash' %}active{% endif %}" hx-get="{% querystring gift_type='cash' %}">{% trans 'Cash Gift' %}</a></li>
+                        <li><a class="{% if gift_type == 'in_kind' %}active{% endif %}" hx-get="{% querystring gift_type='in_kind' %}">{% trans 'In Kind Gift' %}</a></li>
                     </ul>
                 </nav>
                 <div class="py-8 px-12 border-2 border-kara-strong">


### PR DESCRIPTION
## 작업 내용
gift_tag전환 버튼에 정의된 복잡한 속성들을 제거하고 `querystring`태그를 통해 `hx-get`속성만 링크에 추가했습니다.
공통적으로 사용하는 `hx-push-url`속성은  상위에 정의하여 상속을 통해 사용하도록 수정했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
