### PR TITLE
Updated -- 드롭다운 멀티 체크박스 선택 위젯 디자인 수정.

### DIFF
--- a/kara/base/templates/base/widgets/dropdown_checkbox_select_multiple.html
+++ b/kara/base/templates/base/widgets/dropdown_checkbox_select_multiple.html
@@ -11,9 +11,6 @@
         <ul id="{{ widget.attrs.id }}_selected" class="result"></ul>
     </div>
     <div x-show="dropdownPanel" id="{{ widget.attrs.id }}-dropdown-panel" class="dropdown-panel">
-        <div class="panel-title">
-            <h3>{% blocktranslate with label=widget.attrs.label %}Add {{ label }}{% endblocktranslate %}</h3>
-        </div>
         <ul>
             <li id="{{ widget.attrs.id }}_to" class="choose-block">
                 <h3>{% blocktranslate with label=widget.attrs.label %}Selected {{ label }}{% endblocktranslate %}</h3>

--- a/kara/static/css/widgets.css
+++ b/kara/static/css/widgets.css
@@ -71,11 +71,8 @@
     border-radius: 0.5rem;
     border-color: var(--kara-base);
     border-width: 2px;
+    overflow: hidden;
     z-index: 100;
-}
-
-.dropdown-multi-choose .dropdown-panel .panel-title {
-    padding: 10px;
 }
 
 .dropdown-multi-choose .dropdown-panel .choose-block {
@@ -86,10 +83,18 @@
 
 .dropdown-multi-choose .dropdown-panel .choose-block h3 {
     padding: 5px 10px;
-    border-top: 2px solid var(--kara-strong);
     border-bottom: 2px solid var(--kara-strong);
     background-color: var(--kara-base);
     color: white;
+}
+
+.dropdown-multi-choose .dropdown-panel .choose-block:last-of-type h3 {
+    border-top: 2px solid var(--kara-strong);
+}
+
+.dropdown-multi-choose .dropdown-panel .choose-block ul:has(li:nth-child(4)) {
+    height: 250px;
+    overflow: scroll;
 }
 
 /* GIFT TAG SELECT OPTION */


### PR DESCRIPTION
## 작업 내용

드롭다운 멀티 체크박스 위젯은 기존에는 데이터가 많을 수록 위젯의 길이가 길어졌습니다.
하지만 overflow속성을 하위 li요소의 갯수에 따라 적용하게되어 하위 li요소가 특정 개수만큼 늘어났을때 overflow가 적용되고
height을 지정하여 높이도 고정했습니다.
 
<img width="440" alt="Screenshot 2025-07-01 at 8 43 07 AM" src="https://github.com/user-attachments/assets/6a81b484-4d4f-4b61-a454-a6f608deee94" />

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
