### PR TITLE
Refactor -- 축의금 기록 추가 페이지 레이아웃 수정.

### DIFF
--- a/kara/base/templates/base/base.html
+++ b/kara/base/templates/base/base.html
@@ -18,7 +18,7 @@
         {% include 'base/includes/messages.html' %}
         <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
         <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-        <div class="container flex justify-center mb-auto max-w-screen-xl">
+        <div class="container mb-auto max-w-screen-xl">
             <div class="{% block body_width %}w-4/5{% endblock %}">
                 {% block content %}
                 {% endblock %}

--- a/kara/base/templates/base/components/section_header.html
+++ b/kara/base/templates/base/components/section_header.html
@@ -1,7 +1,7 @@
 {% load static i18n %}
 
 
-<div class="my-20 px-32">
+<div class="my-28 px-32">
     <div class="flex items-end text-8xl gap-x-10 tracking-widest">
         <img src="{% static image_path %}" class="h-[8rem] w-[8rem]"></img>
         <h1 class="font-title text-kara-title">{{ title }}</h1>

--- a/kara/wedding_gifts/templates/wedding_gifts/gift_add.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/gift_add.html
@@ -1,21 +1,20 @@
 {% extends "wedding_gifts/base.html" %}
 
-{% load i18n partials tables components %}
+{% load static i18n partials tables components %}
 
 {% block title %}{% blocktranslate with receiver=object.receiver %}Add Gift Record | Kara{% endblocktranslate %}{% endblock %}
 
 {% block meta_title %}{% blocktranslate with receiver=object.receiver %}Add Gift Record | Kara{% endblocktranslate %}{% endblock %}
 
-{% block body_width %}w-full{% endblock %}
+{% block body_width %}w-screen{% endblock %}
 
 {% block content %}
 {{ block.super }}
 {% section_header 'wedding_gifts/img/writing.png' 'Add Wedding Gift Record' 'Record the wedding gifts you received.' %}
-<main class="px-20">
+<main class="my-32">
     <content>
-        <div class="flex">
-            <div class="flex-1">
-                <h2 class="text-2xl text-center my-4">{% translate 'Add Cash Gift Record' %}</h2>
+        <div class="w-[50%] mx-auto">
+            <div>
                 <nav class="tab-selector gift-form">
                     <ul>
                         <li><a class="{% if gift_type == 'cash' %}active{% endif %}" href="{% querystring gift_type='cash' %}">{% trans 'Cash Gift' %}</a></li>
@@ -30,7 +29,6 @@
                     </form>
                 </div>
             </div>
-            <div class="flex-1"></div>
         </div>
     </content>
 </main>


### PR DESCRIPTION
## 작업 내용
축의금 기록 추가 페이지에서 축의금 추가 폼이 존재하는 레이아웃을 수정했습니다.

<img width="1407" alt="Screenshot 2025-07-04 at 5 43 28 PM" src="https://github.com/user-attachments/assets/6bd38228-d0cb-4d9d-9c0d-b52dbab27346" />

위 사진과 같이 폼을 중앙에 배치하고 크기를 수정했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
