### PR TITLE
Fixed -- gift, in_kind 테이블 부분 템플릿 렌더링 영역 수정.

### DIFF
--- a/kara/base/templates/base/tables/table.html
+++ b/kara/base/templates/base/tables/table.html
@@ -1,7 +1,7 @@
 {% load i18n tables base_templatetags %}
 
 <div class="table-container">
-    <table id="table" class="w-full text-left">
+    <table class="w-full text-left">
         <thead class="uppercase" {% if htmx_target %}hx-target="{{ htmx_target }}" hx-swap="outerHTML" hx-push-url="true"{% endif %}>
             <tr>
                 {% for header in table_headers %}

--- a/kara/wedding_gifts/templates/wedding_gifts/gift_table.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/gift_table.html
@@ -25,11 +25,13 @@
             </nav>
             <div class="py-8 px-12">
                 {% if table.search_fields %}
-                {% search_form table htmx_target='#table' %}
+                {% search_form table htmx_target='#partial-table-area' %}
                 {% endif %}
-                {% partialdef table inline %}
-                {% table table htmx_target='#table' %}
-                {% pagination table.pagination htmx_target='#table' %}
+                {% partialdef partial-table-area inline %}
+                <div id="partial-table-area">
+                {% table table htmx_target='#partial-table-area' %}
+                {% pagination table.pagination htmx_target='#partial-table-area' %}
+                </div>
                 {% endpartialdef %}
             </div>
         </div>


### PR DESCRIPTION
## 작업 내용
partial렌더링 영역을 table만 지정하여 partial템플릿 반환시 요소(pagination -> partialdef에 포함된)가 두번 존재하게 되는 문제점이 존재했습니다.
partial렌더링시 계속해서 컴포넌트를 교체해야하는 table, pagination영역 상위 태그에 partial렌더링 id값을 주어 partial렌더링시 table, pagination영역이 교체되도록 수정했습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
