### PR TITLE
Updated -- WeddingGiftRegistry객체를 표현하는 Card형태 컴포넌트 추가.

### DIFF
--- a/kara/wedding_gifts/templates/wedding_gifts/base.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/base.html
@@ -1,6 +1,6 @@
 {% extends "base/base.html" %}
 
-{% load static i18n partials base_components %}
+{% load static i18n partials base_components wedding_gifts_components %}
 
 {% block content %}
 <nav class="w-screen my-20">
@@ -9,41 +9,9 @@
         {% endblock %}
         <div class="relative border-t-4 border-b-4 border-kara-strong overflow-x-scroll">
             {% partialdef registry-selector inline %}
-            <ul id="registry-selector" class="flex gap-10 pt-12 pb-20" hx-target="#registry-selector" hx-push-url="true" hx-swap="outerHTML">
+            <ul id="registry-selector" class="flex gap-40 pt-12 pb-20" hx-target="#registry-selector" hx-push-url="true" hx-swap="outerHTML">
             {% for registry in registries %}
-                <li>
-                    <a hx-get="{% url 'add_gift' pk=registry.pk %}" class="group relative flex flex-col gap-8 items-center p-4 w-[28rem] rounded-md font-bold cursor-pointer text-registry-select-title-color duration-500 {% if registry.pk|stringformat:"s" in request.path %}shadow-[1px_1px_0px_2px_rgba(189,_68,_103,_0.75),_0_20px_65px_rgba(189,_68,_103,_0.6)] translate-x-[2px] translate-y-[2px]{% else %}shadow-[3px_3px_0px_5px_rgba(189,_68,_103,_0.75)] hover:shadow-[1px_1px_0px_2px_rgba(189,_68,_103,_0.75)] hover:translate-x-[2px] hover:translate-y-[2px]{% endif %} first:ml-40 last:ml-40">
-                        <img class="absolute w-[30px] h-[30px] top-3 right-8 group-hover:opacity-100 {% if registry.pk|stringformat:"s" in request.path %}opacity-100{% else %}opacity-0{% endif %}" src="{% static 'wedding_gifts/img/check.png' %}"></img>
-                        <p class="text-xl font-sub-title relative z-10 before:content-[''] before:absolute before:top-[60%] before:left-0 before:w-0 before:h-[40%] before:bg-gradient-to-r before:from-yellow-200 before:to-yellow-300 before:transition-all before:duration-500 before:-z-10 {% if registry.pk|stringformat:"s" in request.path %}before:w-full{% else %}group-hover:before:w-full{% endif %}">
-                            {% blocktranslate with receiver=registry.receiver side=registry.get_side_display %}{{ side }} {{ receiver }}'s wedding gift records{% endblocktranslate %}
-                        </p>
-                        <div class="w-full flex flex-col items-end font-medium">
-                            <img class="m-auto w-[20rem] h-[20rem] mb-8" alt="registry-cover-image" src="{% static registry.cover_image %}"/>
-                            <div class="ml-auto">
-                                <div class="grid grid-cols-[80px_20px_1fr] gap-1">
-                                    <span>{% trans 'Wedding Date' %}</span>
-                                    <span>:</span>
-                                    <span>{{ registry.wedding_date }}</span>
-                                </div>
-                                <div class="grid grid-cols-[80px_20px_1fr] gap-1">
-                                    <span>{% trans 'Receptionist' %}</span>
-                                    <span>:</span>
-                                    <span>{{ registry.receptionist }}</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="flex flex-col font-medium">
-                            <div class="flex items-center">
-                                <img class="w-[35px] h-[35px] mr-4" alt="cash-gift" src="{% static 'wedding_gifts/img/money.png' %}"/>
-                                <span>{% blocktranslate with cash_gift_cnt=registry.cash_gift_cnt %}There are {{ cash_gift_cnt }} records of cash gifts{% endblocktranslate %}</span>
-                            </div>
-                            <div class="flex items-center mr-4">
-                                <img class="w-[35px] h-[35px] mr-4" alt="in-kind-gift" src="{% static 'wedding_gifts/img/gift-card.png' %}"/>
-                                <span>{% blocktranslate with in_kind_gift_cnt=registry.in_kind_gift_cnt %}There are {{ in_kind_gift_cnt }} records of in kind gifts{% endblocktranslate %}</span>
-                            </div>
-                        </div>
-                    </a>
-                </li>
+                <li class="first:pl-40 last:pr-40">{% registry_card registry 'add_gift' %}</li>
             {% endfor %}
             </ul>
             {% endpartialdef %}

--- a/kara/wedding_gifts/templates/wedding_gifts/components/registry_card.html
+++ b/kara/wedding_gifts/templates/wedding_gifts/components/registry_card.html
@@ -1,0 +1,33 @@
+{% load i18n static %}
+
+<a {% if htmx %}hx-get{% else %}href{% endif %}="{% url url_name pk=registry.pk %}" class="group relative flex flex-col gap-8 items-center p-4 w-[28rem] rounded-md font-bold cursor-pointer text-registry-select-title-color duration-500 {% if registry.pk|stringformat:"s" in request.path %}shadow-[1px_1px_0px_2px_rgba(189,_68,_103,_0.75),_0_20px_65px_rgba(189,_68,_103,_0.6)] translate-x-[2px] translate-y-[2px]{% else %}shadow-[3px_3px_0px_5px_rgba(189,_68,_103,_0.75)] hover:shadow-[1px_1px_0px_2px_rgba(189,_68,_103,_0.75)] hover:translate-x-[2px] hover:translate-y-[2px]{% endif %}">
+    <img class="absolute w-[30px] h-[30px] top-3 right-8 group-hover:opacity-100 {% if registry.pk|stringformat:"s" in request.path %}opacity-100{% else %}opacity-0{% endif %}" src="{% static 'wedding_gifts/img/check.png' %}"></img>
+    <p class="text-xl font-sub-title relative z-10 before:content-[''] before:absolute before:top-[60%] before:left-0 before:w-0 before:h-[40%] before:bg-gradient-to-r before:from-yellow-200 before:to-yellow-300 before:transition-all before:duration-500 before:-z-10 {% if registry.pk|stringformat:"s" in request.path %}before:w-full{% else %}group-hover:before:w-full{% endif %}">
+        {% blocktranslate with receiver=registry.receiver side=registry.get_side_display %}{{ side }} {{ receiver }}'s wedding gift records{% endblocktranslate %}
+    </p>
+    <div class="w-full flex flex-col items-end font-medium">
+        <img class="m-auto w-[20rem] h-[20rem] mb-8" alt="registry-cover-image" src="{% static registry.cover_image %}"/>
+        <div class="ml-auto">
+            <div class="grid grid-cols-[80px_20px_1fr] gap-1">
+                <span>{% trans 'Wedding Date' %}</span>
+                <span>:</span>
+                <span>{{ registry.wedding_date }}</span>
+            </div>
+            <div class="grid grid-cols-[80px_20px_1fr] gap-1">
+                <span>{% trans 'Receptionist' %}</span>
+                <span>:</span>
+                <span>{{ registry.receptionist }}</span>
+            </div>
+        </div>
+    </div>
+    <div class="flex flex-col font-medium">
+        <div class="flex items-center">
+            <img class="w-[35px] h-[35px] mr-4" alt="cash-gift" src="{% static 'wedding_gifts/img/money.png' %}"/>
+            <span>{% blocktranslate with cash_gift_cnt=registry.cash_gift_cnt %}There are {{ cash_gift_cnt }} records of cash gifts{% endblocktranslate %}</span>
+        </div>
+        <div class="flex items-center mr-4">
+            <img class="w-[35px] h-[35px] mr-4" alt="in-kind-gift" src="{% static 'wedding_gifts/img/gift-card.png' %}"/>
+            <span>{% blocktranslate with in_kind_gift_cnt=registry.in_kind_gift_cnt %}There are {{ in_kind_gift_cnt }} records of in kind gifts{% endblocktranslate %}</span>
+        </div>
+    </div>
+</a>

--- a/kara/wedding_gifts/templatetags/wedding_gifts_components.py
+++ b/kara/wedding_gifts/templatetags/wedding_gifts_components.py
@@ -4,6 +4,15 @@ from django.utils.translation import gettext_lazy as _
 register = Library()
 
 
+@register.inclusion_tag("wedding_gifts/components/registry_card.html")
+def registry_card(registry, url_name, htmx=False):
+    return {
+        "registry": registry,
+        "url_name": url_name,
+        "htmx": htmx,
+    }
+
+
 @register.inclusion_tag(
     "wedding_gifts/components/footer_navigation.html", name="footer_navigation"
 )


### PR DESCRIPTION
## 작업 내용

`WeddingGiftRegistry`객체를 표현하는 Card형태의 컴포넌트를 추가했습니다.

<img width="432" alt="Screenshot 2025-07-09 at 7 00 19 PM" src="https://github.com/user-attachments/assets/5d1615c9-dcc6-4b7e-a439-47dda13a1c0e" />

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [x] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
