### PR TITLE
Updated -- 페이지네이션 컴포넌트 커스텀 쿼리 파라미터 허용.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -271,7 +271,6 @@ NPM_BIN_PATH = "/usr/bin/npm"
 
 # QUERYSTRING
 # ------------------------------------------------------------------------------
-PAGE_VAR = "page"
 SEARCH_VAR = "search"
 ORDER_VAR = "order"
 

--- a/kara/base/pagination.py
+++ b/kara/base/pagination.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.paginator import InvalidPage, Paginator
 
 from .exceptions import IncorectLookupParameter
@@ -10,15 +9,17 @@ class Pagination:
         request,
         queryset,
         list_per_page,
+        page_var="page",
     ):
         self.queryset = queryset
         model = queryset.model
         self.model = model
         self.opts = model._meta
         self.list_per_page = list_per_page
+        self.page_var = page_var
         try:
             # Get the current page from the query string.
-            self.page_num = int(request.GET.get(settings.PAGE_VAR, 1))
+            self.page_num = int(request.GET.get(self.page_var, 1))
         except ValueError:
             self.page_num = 1
         self.params = request.GET.copy()

--- a/kara/base/tables.py
+++ b/kara/base/tables.py
@@ -28,10 +28,13 @@ class Table:
     ordering = []
     columns = "__all__"
 
-    def __init__(self, request, model, base_queryset, list_per_page=100):
+    def __init__(
+        self, request, model, base_queryset, list_per_page=100, page_var="page"
+    ):
         self.model = model
         self.opts = model._meta
         self.list_per_page = list_per_page
+        self.page_var = page_var
         if self.columns == "__all__":
             # Displays all model fields if columns are not specified
             self.columns = [
@@ -44,8 +47,8 @@ class Table:
         self.search_form = search_form
         self.search_value = self.search_form.cleaned_data.get(settings.SEARCH_VAR) or ""
         self.params = dict(request.GET.lists())
-        if settings.PAGE_VAR in self.params:
-            del self.params[settings.PAGE_VAR]
+        if self.page_var in self.params:
+            del self.params[self.page_var]
         self.result_objects = self.get_queryset(request, base_queryset)
 
     def display_for_value(self, obj, column):
@@ -133,6 +136,7 @@ class Table:
             request,
             queryset,
             self.list_per_page,
+            self.page_var,
         )
         self.pagination = pagination
         return pagination.get_objects()

--- a/kara/base/templatetags/tables.py
+++ b/kara/base/templatetags/tables.py
@@ -18,7 +18,7 @@ def pagination_number(pagination, i, htmx):
     elif i == pagination.page_num:
         return format_html('<em class="current-page" aria-current="page">{}</em> ', i)
     else:
-        link = querystring(None, pagination.params, {settings.PAGE_VAR: i})
+        link = querystring(None, pagination.params, {pagination.page_var: i})
         link_key = "href" if htmx is None else "hx-get"
         return format_html(
             '<a {}="{}" aria-label="page {}" {}>{}</a> ',
@@ -36,8 +36,8 @@ def pagination_tag(pagination, **kwargs):
     next_page_num = pagination.page_num + 1
     return {
         "pagination": pagination,
-        "previous_page": {settings.PAGE_VAR: previous_page_num},
-        "next_page": {settings.PAGE_VAR: next_page_num},
+        "previous_page": {pagination.page_var: previous_page_num},
+        "next_page": {pagination.page_var: next_page_num},
         **kwargs,
     }
 


### PR DESCRIPTION
## 작업 내용
페이지네이션 컴포넌트에 커스텀 쿼리 파라미터를 허용합니다.
즉 한 페이지내에서 페이지네이션이 여러개 존재할 수 있게 되었습니다.
기존에는 고정된 page를 사용했지만 커스텀 쿼리 파라미터를 통해 쿼리스트링이 겹치지 않게 적용할 수 있습니다.

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
