### PR TITLE
Fixed -- 이미지 선택 위젯 최초 렌더링 처리 추가.

### DIFF
--- a/kara/base/static/base/js/imageSelect.js
+++ b/kara/base/static/base/js/imageSelect.js
@@ -9,3 +9,12 @@ options.forEach((option) => {
         }
     })
 })
+
+// Apply the initial value (checked) when rendering the page.
+window.addEventListener("load", () => {
+    options.forEach((option) => {
+        if (option.checked) {
+            selectedImage.src = option.dataset.staticUrl;
+        }
+    })
+})

--- a/kara/base/templates/base/widgets/image_select.html
+++ b/kara/base/templates/base/widgets/image_select.html
@@ -18,7 +18,7 @@
             {% for group_name, group_choices, group_index in widget.optgroups %}
                 {% for option in group_choices %}
                     <li class="border-[1.5px] border-kara-base bg-kara-white" @click="showImageSelectDialog = false">
-                        <input class="peer hidden w-full h-full" id="{{ option.attrs.id }}" type="radio" name={{ option.name }} value="{{ option.value }}" data-static-url="{% static option.value %}">
+                        <input class="peer hidden w-full h-full" id="{{ option.attrs.id }}" type="radio" name={{ option.name }} value="{{ option.value }}" {% if option.attrs.checked %}checked="true"{% endif %} data-static-url="{% static option.value %}">
                         <label class="block p-4 peer-checked:bg-kara-strong cursor-pointer hover:bg-kara-base" for="{{ option.attrs.id }}">
                             <img class="w-[4rem] h-[4rem]" src="{% static option.value %}"/>
                         </label>


### PR DESCRIPTION
## 작업 내용
이미지 선택 위젯이 최초로 렌더링시에 이미 지정된 이미지가 존재하다면 해당 이미지를 렌더링하도록 수정했습니다. 

## 연관된 작업

- ❌

## 연관된 이슈

- ❌

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [ ] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
