### PR TITLE
Updated -- 결혼 선물 저장소 디테일 페이지 테스트 추가.

### DIFF
--- a/kara/wedding_gifts/tests/test_registry_views.py
+++ b/kara/wedding_gifts/tests/test_registry_views.py
@@ -1,10 +1,15 @@
+import factory
 import pytest
 from django.test import TestCase
 from django.urls import reverse
 from playwright.sync_api import expect
 
 from kara.accounts.factories import UserFactory
-from kara.wedding_gifts.factories import WeddingGiftRegistryFactory
+from kara.wedding_gifts.factories import (
+    CashGiftFactory,
+    InKindGiftFactory,
+    WeddingGiftRegistryFactory,
+)
 from kara.wedding_gifts.models import WeddingGiftRegistry
 
 
@@ -36,6 +41,70 @@ class RegistryAddViewTests(TestCase):
         )
         registry = WeddingGiftRegistry.objects.filter(receiver="evian")
         self.assertTrue(registry.exists())
+
+
+class RegistryDetailViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(
+            username="samdasu123", email="samdasu123@water.com", password="password"
+        )
+        cls.registry = WeddingGiftRegistryFactory.create(
+            owner=cls.user,
+            side="Groom",
+            receiver="Purple",
+            receptionist="Orange",
+        )
+        cls.url = reverse("detail_registry", args=(cls.registry.pk,))
+        cash_gift_prices = [10000, 50000, 100000, 200000, 500000]
+        cls.total_cash_gift_price = sum(cash_gift_prices)
+        CashGiftFactory.create_batch(
+            5,
+            price=factory.Iterator(cash_gift_prices),
+            registry=cls.registry,
+        )
+        in_kind_gift_prices = [70000, 170000, 370000]
+        cls.total_in_kind_gift_price = sum(in_kind_gift_prices)
+        InKindGiftFactory.create_batch(
+            3,
+            price=factory.Iterator(in_kind_gift_prices),
+            registry=cls.registry,
+        )
+
+    def setUp(self):
+        self.client.force_login(self.user)
+
+    def test_template_render(self):
+        response = self.client.get(self.url)
+        # Simple registry insight value
+        self.assertContains(response, f'data-count="{self.total_cash_gift_price}"')
+        self.assertContains(response, 'data-count="5"')
+        self.assertContains(response, f'data-count="{self.total_in_kind_gift_price}"')
+        self.assertContains(response, 'data-count="3"')
+        total_price = self.total_cash_gift_price + self.total_in_kind_gift_price
+        self.assertContains(response, f'data-count="{total_price}"')
+
+    def test_update_registry(self):
+        response = self.client.post(
+            self.url,
+            data={
+                "cover_image": self.registry.cover_image,
+                "side": "Bride",
+                "receiver": "Green",
+                "receptionist": "Blue",
+                "wedding_date_0": "2003",
+                "wedding_date_1": "8",
+                "wedding_date_2": "6",
+            },
+            follow=True,
+        )
+        self.registry.refresh_from_db()
+        self.assertEqual(self.registry.side, "Bride")
+        self.assertEqual(self.registry.receiver, "Green")
+        self.assertEqual(self.registry.receptionist, "Blue")
+        self.assertContains(
+            response, "The wedding gift registry has been successfully updated!"
+        )
 
 
 @pytest.mark.playwright


### PR DESCRIPTION
## 작업 내용
결혼 선물 저장소 디테일 페이지 테스트코드를 추가했습니다.

## 연관된 작업

- 

## 연관된 이슈

- https://github.com/Antoliny0919/kara/issues/220

## 체크사항
- [x] PR을 `main`브랜치 대상으로 생성했나요?
- [x] 추가된 동작과 관련된 테스트코드를 추가했나요?
- [ ] UI가 변경된 부분이 있다면 스크린샷을 첨부했나요?
